### PR TITLE
FBox Integration

### DIFF
--- a/builds/RV64ADFIMSU_Bluesim/Makefile
+++ b/builds/RV64ADFIMSU_Bluesim/Makefile
@@ -1,0 +1,11 @@
+###  -*-Makefile-*-
+
+# Copyright (c) 2018 Bluespec, Inc. All Rights Reserved
+
+# ================================================================
+
+include ../Resources/Include_RV64ADFIMSU.mk
+
+include ../Resources/Include_Bluesim.mk
+
+# ================================================================

--- a/builds/RV64ADFIMSU_verilator/Makefile
+++ b/builds/RV64ADFIMSU_verilator/Makefile
@@ -1,0 +1,10 @@
+###  -*-Makefile-*-
+
+# Copyright (c) 2018 Bluespec, Inc. All Rights Reserved
+
+# ================================================================
+
+include ../Resources/Include_RV64ADFIMSU.mk
+include ../Resources/Include_verilator.mk
+
+# ================================================================

--- a/builds/Resources/Include_RV32ACDFIMSU.mk
+++ b/builds/Resources/Include_RV32ACDFIMSU.mk
@@ -1,0 +1,30 @@
+###  -*-Makefile-*-
+
+# Copyright (c) 2018 Bluespec, Inc. All Rights Reserved
+
+# This file is not a standalone Makefile, but 'include'd by 'Makefile' in the sub-directories
+
+# ================================================================
+# bsc flags to build for RV32 A, C, D, F, I, M, S, U
+
+# Implementation choice: SHIFT_BARREL, SHIFT_SERIAL, SHIFT_MULT, SHIFT_NONE
+# Implementation choice: MULT_SYNTH, MULT_SERIAL
+
+BSC_FLAGS ?= -D RV32 \
+	     -D SHIFT_BARREL \
+	     -D MULT_SYNTH \
+	     -D CSR_REGFILE_MSU \
+	     -D ISA_PRIV_M \
+	     -D ISA_PRIV_U \
+	     -D ISA_PRIV_S  -D SV32 \
+	     -D ISA_C \
+	     -D ISA_F \
+	     -D ISA_D \
+	     -D ISA_M \
+	     -D ISA_A
+
+# Default ISA test
+
+TEST ?= rv32uf-p-fadd
+
+# ================================================================

--- a/builds/Resources/Include_RV64ADFIMSU.mk
+++ b/builds/Resources/Include_RV64ADFIMSU.mk
@@ -1,0 +1,29 @@
+###  -*-Makefile-*-
+
+# Copyright (c) 2018 Bluespec, Inc. All Rights Reserved
+
+# This file is not a standalone Makefile, but 'include'd by 'Makefile' in the sub-directories
+
+# ================================================================
+# bsc flags to build for RV32 A, D, F, I, M, S, U
+
+# Implementation choice: SHIFT_BARREL, SHIFT_SERIAL, SHIFT_MULT, SHIFT_NONE
+# Implementation choice: MULT_SYNTH, MULT_SERIAL
+
+BSC_FLAGS ?= -D RV64 \
+	     -D SHIFT_BARREL \
+	     -D MULT_SYNTH \
+	     -D CSR_REGFILE_MSU \
+	     -D ISA_PRIV_M \
+	     -D ISA_PRIV_U \
+	     -D ISA_PRIV_S  -D SV39 \
+	     -D ISA_F \
+	     -D ISA_D \
+	     -D ISA_M \
+	     -D ISA_A
+
+# Default ISA test
+
+TEST ?= rv64uf-p-fadd
+
+# ================================================================

--- a/src_Core/Core/CPU_IFC.bsv
+++ b/src_Core/Core/CPU_IFC.bsv
@@ -70,6 +70,11 @@ interface CPU_IFC;
    // GPR access
    interface MemoryServer #(5,  XLEN)  hart0_gpr_mem_server;
 
+`ifdef ISA_F
+   // FPR access
+   interface MemoryServer #(5,  FLEN) hart0_fpr_mem_server;
+`endif
+
    // CSR access
    interface MemoryServer #(12, XLEN)  hart0_csr_mem_server;
 `endif

--- a/src_Core/Core/CPU_Stage1.bsv
+++ b/src_Core/Core/CPU_Stage1.bsv
@@ -1,4 +1,5 @@
-// Copyright (c) 2016-2018 Bluespec, Inc. All Rights Reserved
+// vim: tw=80:tabstop=8:softtabstop=3:shiftwidth=3:expandtab:
+// Copyright (c) 2016-2019 Bluespec, Inc. All Rights Reserved
 
 package CPU_Stage1;
 
@@ -34,6 +35,9 @@ import ISA_Decls        :: *;
 import CPU_Globals      :: *;
 import Near_Mem_IFC     :: *;
 import GPR_RegFile      :: *;
+`ifdef ISA_F
+import FPR_RegFile      :: *;
+`endif
 import CSR_RegFile      :: *;
 import EX_ALU_functions :: *;
 
@@ -69,12 +73,14 @@ endinterface
 
 module mkCPU_Stage1 #(Bit #(4)         verbosity,
 		      GPR_RegFile_IFC  gpr_regfile,
-`ifdef ISA_F
-		      FPR_RegFile_IFC  fpr_regfile,
-`endif
-		      CSR_RegFile_IFC  csr_regfile,
 		      Bypass           bypass_from_stage2,
 		      Bypass           bypass_from_stage3,
+`ifdef ISA_F
+		      FPR_RegFile_IFC  fpr_regfile,
+		      FBypass          fbypass_from_stage2,
+		      FBypass          fbypass_from_stage3,
+`endif
+		      CSR_RegFile_IFC  csr_regfile,
 		      Epoch            cur_epoch,
 		      Priv_Mode        cur_priv)
                     (CPU_Stage1_IFC);
@@ -116,34 +122,72 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    Bool rs2_busy = (busy2a || busy2b);
    Word rs2_val_bypassed = ((rs2 == 0) ? 0 : rs2b);
 
-   // ALU function
-   let alu_inputs = ALU_Inputs {cur_priv:       cur_priv,
-				pc:             rg_stage_input.pc,
-				is_i32_not_i16: True,    // TODO: fix with 'C' info
-				instr:          rg_stage_input.instr,
-`ifdef ISA_C
-				instr_C:        instr_C,
-`endif
-				decoded_instr:  rg_stage_input.decoded_instr,
-				rs1_val:        rs1_val_bypassed,
-				rs2_val:        rs2_val_bypassed,
-				mstatus:        csr_regfile.read_mstatus,
-				misa:           csr_regfile.read_misa};
+`ifdef ISA_F
+   // FP Register rs1 read and bypass
+   let frs1_val = fpr_regfile.read_rs1 (rs1);
+   match { .fbusy1a, .frs1a } = fn_fpr_bypass (fbypass_from_stage3, rs1, frs1_val);
+   match { .fbusy1b, .frs1b } = fn_fpr_bypass (fbypass_from_stage2, rs1, frs1a);
+   Bool frs1_busy = (fbusy1a || fbusy1b);
+   WordFL frs1_val_bypassed = frs1b;
 
+   // FP Register rs2 read and bypass
+   let frs2_val = fpr_regfile.read_rs2 (rs2);
+   match { .fbusy2a, .frs2a } = fn_fpr_bypass (fbypass_from_stage3, rs2, frs2_val);
+   match { .fbusy2b, .frs2b } = fn_fpr_bypass (fbypass_from_stage2, rs2, frs2a);
+   Bool frs2_busy = (fbusy2a || fbusy2b);
+   WordFL frs2_val_bypassed = frs2b;
+
+   // FP Register rs3 read and bypass
+   let rs3 = decoded_instr.rs3;
+   let frs3_val = fpr_regfile.read_rs3 (rs3);
+   match { .fbusy3a, .frs3a } = fn_fpr_bypass (fbypass_from_stage3, rs3, frs3_val);
+   match { .fbusy3b, .frs3b } = fn_fpr_bypass (fbypass_from_stage2, rs3, frs3a);
+   Bool frs3_busy = (fbusy3a || fbusy3b);
+   WordFL frs3_val_bypassed = frs3b;
+`endif
+
+   // ALU function
+   let alu_inputs = ALU_Inputs {
+        cur_priv        : cur_priv
+      , pc              : rg_stage_input.pc
+      , is_i32_not_i16  : True     // TODO: fix with 'C' info
+      , instr           : rg_stage_input.instr
+`ifdef ISA_C
+      , instr_C         : instr_C
+`endif
+      , decoded_instr   : rg_stage_input.decoded_instr
+      , rs1_val         : rs1_val_bypassed
+      , rs2_val         : rs2_val_bypassed
+`ifdef ISA_F
+      , frs1_val        : frs1_val_bypassed
+      , frs2_val        : frs2_val_bypassed
+      , frs3_val        : frs3_val_bypassed
+      , fcsr_frm        : csr_regfile.read_frm
+`endif
+      , mstatus         : csr_regfile.read_mstatus
+      , misa            : csr_regfile.read_misa
+   }; 
    let alu_outputs = fv_ALU (alu_inputs);
 
-   let data_to_stage2 = Data_Stage1_to_Stage2 {priv:      cur_priv,
-					       pc:        rg_stage_input.pc,
-					       instr:     rg_stage_input.instr,
-					       op_stage2: alu_outputs.op_stage2,
-					       rd:        alu_outputs.rd,
-					       addr:      alu_outputs.addr,
-					       val1:      alu_outputs.val1,
-					       val2:      alu_outputs.val2
-`ifdef INCLUDE_TANDEM_VERIF
-					       , trace_data: alu_outputs.trace_data
+   let data_to_stage2 = Data_Stage1_to_Stage2 {
+        priv            : cur_priv
+      , pc              : rg_stage_input.pc
+      , instr           : rg_stage_input.instr
+      , op_stage2       : alu_outputs.op_stage2
+      , rd              : alu_outputs.rd
+      , addr            : alu_outputs.addr
+      , val1            : alu_outputs.val1
+      , val2            : alu_outputs.val2
+`ifdef ISA_F
+      , val3            : alu_outputs.val3
+      , rd_in_fpr       : alu_outputs.rd_in_fpr
+      , rounding_mode   : alu_outputs.rm
 `endif
-					       };
+
+`ifdef INCLUDE_TANDEM_VERIF
+      , trace_data      : alu_outputs.trace_data
+`endif
+   };
 
    // ----------------
    // Combinational output function
@@ -170,8 +214,13 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 						     addr:      ?,
 						     val1:      ?,
 						     val2:      ?
+`ifdef ISA_F
+                                                   , val3            : ?
+                                                   , rd_in_fpr       : ?
+                                                   , rounding_mode   : ?
+`endif
 `ifdef INCLUDE_TANDEM_VERIF
-						     , trace_data: alu_outputs.trace_data
+						   , trace_data: alu_outputs.trace_data
 `endif
 						     };
 

--- a/src_Core/Core/CPU_Stage2.bsv
+++ b/src_Core/Core/CPU_Stage2.bsv
@@ -1,4 +1,5 @@
-// Copyright (c) 2016-2018 Bluespec, Inc. All Rights Reserved
+// vim: tw=80:tabstop=8:softtabstop=3:shiftwidth=3:expandtab:
+// Copyright (c) 2016-2019 Bluespec, Inc. All Rights Reserved
 
 package CPU_Stage2;
 
@@ -59,7 +60,7 @@ import Shifter_Box  :: *;
 import RISCV_MBox  :: *;
 `endif
 
-`ifdef ISA_FD
+`ifdef ISA_F
 import RISCV_FBox  :: *;
 `endif
 
@@ -116,30 +117,57 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
    // ----------------
    // Floating point box
 
-`ifdef ISA_FD
+`ifdef ISA_F
    RISCV_FBox_IFC fbox <- mkRISCV_FBox;
 `endif
 
    // ----------------
 
-   let bypass_base = Bypass {bypass_state: BYPASS_RD_NONE,
-			     rd:           rg_stage2.rd,
-			     rd_val:       rg_stage2.val1 };
+   let bypass_base = Bypass {bypass_state: BYPASS_RD_NONE
+			   , rd:           rg_stage2.rd
+`ifdef ISA_D
+			   , rd_val:       truncate (rg_stage2.val1) 
+`else
+			   , rd_val:       rg_stage2.val1 
+`endif
+                           };
+
+`ifdef ISA_F
+   let fbypass_base = FBypass {bypass_state: BYPASS_RD_NONE
+			   , rd:           rg_stage2.rd
+`ifdef ISA_D
+			   , rd_val:       rg_stage2.val1 
+`else
+`ifdef RV64
+			   , rd_val:       extend (rg_stage2.val1) 
+`else
+			   , rd_val:       rg_stage2.val1 
+`endif
+`endif
+                           };
+`endif
 
    let data_to_stage3_base = Data_Stage2_to_Stage3 {priv:      rg_stage2.priv,
 						    pc:        rg_stage2.pc,
 						    instr:     rg_stage2.instr,
+`ifdef ISA_F
+                                                    rd_in_fpr: False,
+                                                    upd_flags: False,
+                                                    fpr_flags: 0,
+`endif
 						    rd_valid:  False,
 						    rd:        rg_stage2.rd,
-						    rd_val:    rg_stage2.val1};
+						    rd_val:    rg_stage2.val1
+                                                 };
 
    let  trap_info_dmem = Trap_Info {epc:      rg_stage2.pc,
 				    exc_code: dcache.exc_code,
 				    tval:     rg_stage2.addr };
 
-`ifdef ISA_FD
+`ifdef ISA_F
+   // The FBox can only generate ILLEGAL Instruction exceptions
    let  trap_info_fbox = Trap_Info {epc:      rg_stage2.pc,
-				    exc_code: fbox.exc_code,
+				    exc_code: exc_code_ILLEGAL_INSTRUCTION,
 				    tval:     0 };
 `endif
 
@@ -164,6 +192,9 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 					trap_info:       ?,
 					data_to_stage3:  ?,
 					bypass:          no_bypass,
+`ifdef ISA_F
+					fbypass:         no_fbypass,
+`endif
 					trace_data:      ?
 					};
       end
@@ -185,6 +216,9 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 					trap_info:       ?,
 					data_to_stage3:  data_to_stage3,
 					bypass:          bypass,
+`ifdef ISA_F
+					fbypass:         no_fbypass,
+`endif
 					trace_data:      trace_data};
       end
 
@@ -205,13 +239,41 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 
 	    let data_to_stage3 = data_to_stage3_base;
 	    data_to_stage3.rd_valid = (ostatus == OSTATUS_PIPE);
+`ifdef ISA_D
+	    data_to_stage3.rd_val   = dcache.word64;
+`else
 	    data_to_stage3.rd_val   = result;
+`endif
 
+            // Update the bypass channel
 	    let bypass = bypass_base;
+
+`ifdef ISA_F
+            // When FP is enabled the LD result may be meant for a FPR or a GPR.
+            // Check before updating the appropriate bypass channel
+            let upd_fpr             = rg_stage2.rd_in_fpr;
+	    let fbypass             = fbypass_base;
+            data_to_stage3.rd_in_fpr= upd_fpr;
+
+            if (upd_fpr) begin
+	       fbypass.bypass_state = ((ostatus == OSTATUS_PIPE) ? BYPASS_RD_RDVAL : BYPASS_RD);
+`ifdef ISA_D
+	       fbypass.rd_val       = dcache.word64;
+`else
+	       fbypass.rd_val       = result;
+`endif
+            end
+
+            else if (rg_stage2.rd != 0) begin    // TODO: is this test necessary?
+	       bypass.bypass_state = ((ostatus == OSTATUS_PIPE) ? BYPASS_RD_RDVAL : BYPASS_RD);
+	       bypass.rd_val       = result;
+	    end
+`else
 	    if (rg_stage2.rd != 0) begin    // TODO: is this test necessary?
 	       bypass.bypass_state = ((ostatus == OSTATUS_PIPE) ? BYPASS_RD_RDVAL : BYPASS_RD);
 	       bypass.rd_val       = result;
 	    end
+`endif
 
 	    let trace_data   = ?;
 `ifdef INCLUDE_TANDEM_VERIF
@@ -223,6 +285,9 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 					   trap_info:       trap_info_dmem,
 					   data_to_stage3:  data_to_stage3,
 					   bypass:          bypass,
+`ifdef ISA_F
+					   fbypass:         fbypass,
+`endif
 					   trace_data:      trace_data};
 	 end
 
@@ -248,6 +313,9 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 					trap_info:      trap_info_dmem,
 					data_to_stage3: data_to_stage3,
 					bypass:         no_bypass,
+`ifdef ISA_F
+					fbypass:        no_fbypass,
+`endif
 					trace_data:     trace_data};
       end
 
@@ -260,7 +328,11 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 
 	 let data_to_stage3 = data_to_stage3_base;
 	 data_to_stage3.rd_valid = (ostatus == OSTATUS_PIPE);
+`ifdef ISA_D
+	 data_to_stage3.rd_val   = extend (result);
+`else
 	 data_to_stage3.rd_val   = result;
+`endif
 
 	 let bypass = bypass_base;
 	 bypass.bypass_state = ((ostatus == OSTATUS_PIPE) ? BYPASS_RD_RDVAL : BYPASS_RD);
@@ -276,6 +348,9 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 					trap_info:       ?,
 					data_to_stage3:  data_to_stage3,
 					bypass:          bypass,
+`ifdef ISA_F
+					fbypass:         no_fbypass,
+`endif
 					trace_data:      trace_data};
       end
 `endif
@@ -289,7 +364,11 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 
 	 let data_to_stage3 = data_to_stage3_base;
 	 data_to_stage3.rd_valid = (ostatus == OSTATUS_PIPE);
+`ifdef ISA_D
+	 data_to_stage3.rd_val   = extend (result);
+`else
 	 data_to_stage3.rd_val   = result;
+`endif
 
 	 let bypass = bypass_base;
 	 bypass.bypass_state = ((ostatus == OSTATUS_PIPE) ? BYPASS_RD_RDVAL : BYPASS_RD);
@@ -305,39 +384,69 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 					trap_info:       ?,
 					data_to_stage3:  data_to_stage3,
 					bypass:          bypass,
+`ifdef ISA_F
+					fbypass:         no_fbypass,
+`endif
 					trace_data:      trace_data};
       end
 `endif
 
-`ifdef ISA_FD
+`ifdef ISA_F
       // This stage is doing a floating point op
       else if (rg_stage2.op_stage2 == OP_Stage2_FD) begin
-	 let ostatus = (  (! fbox.valid)
-			? OSTATUS_BUSY
-			: (  fbox.exc
-			   ? OSTATUS_NONPIPE
-			   : OSTATUS_PIPE));
+	 let ostatus = ((! fbox.valid) ? OSTATUS_BUSY : OSTATUS_PIPE);
 
-	 let result = fbox.word;
+         // Extract fields from FBOX result
+	 match {.value, .fflags} = fbox.word;
+         let upd_fpr             = rg_stage2.rd_in_fpr;
 
-	 let data_to_stage3 = data_to_stage3_base;
+	 let data_to_stage3      = data_to_stage3_base;
 	 data_to_stage3.rd_valid = (ostatus == OSTATUS_PIPE);
-	 data_to_stage3.rd_val   = result;
+	 data_to_stage3.rd_val   = value;
+         data_to_stage3.rd_in_fpr= rg_stage2.rd_in_fpr;
+         data_to_stage3.upd_flags= True;
+         data_to_stage3.fpr_flags= fflags;
 
-	 let bypass = bypass_base;
-	 bypass.bypass_state = ((ostatus == OSTATUS_PIPE) ? BYPASS_RD_RDVAL : BYPASS_RD);
-	 bypass.rd_val       = result;
+         // result is meant for a FPR
+         let bypass              = bypass_base;
+         let fbypass             = fbypass_base;
+         if (upd_fpr) begin
+            fbypass.bypass_state    = ((ostatus==OSTATUS_PIPE) ? BYPASS_RD_RDVAL
+                                                               : BYPASS_RD);
+`ifdef ISA_D
+            fbypass.rd_val          = value;
+`else
+            fbypass.rd_val          = truncate (value);
+`endif
+         end
 
-	 let trace_data   = ?;
+         // result is meant for a GPR
+         else begin
+            bypass.bypass_state     = ((ostatus==OSTATUS_PIPE) ? BYPASS_RD_RDVAL
+                                                               : BYPASS_RD);
+`ifdef RV64
+            bypass.rd_val           = (value);
+`else
+            bypass.rd_val           = truncate (value);
+`endif
+         end
+
+         // -----
+	 let trace_data          = ?;
 `ifdef INCLUDE_TANDEM_VERIF
 	 trace_data   = rg_stage2.trace_data;
 `endif
-	 trace_data.word1 = result;
+         // XXX Revisit. word1 should be sized similar to val (always 64-bit) if
+         // FPU is enabled
+	 trace_data.word1 = truncate (value);
 
 	 output_stage2 = Output_Stage2 {ostatus:         ostatus,
 					trap_info:       trap_info_fbox,
 					data_to_stage3:  data_to_stage3,
 					bypass:          bypass,
+`ifdef ISA_F
+					fbypass:         fbypass,
+`endif
 					trace_data:      trace_data};
       end
 `endif
@@ -389,7 +498,11 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 			amo_funct7,
 `endif
 			x.addr,
+`ifdef ISA_D
+			x.val2,
+`else
 			zeroExtend (x.val2),
+`endif
 			mem_priv,
 			sstatus_SUM,
 			mstatus_MXR,
@@ -399,21 +512,73 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 `ifdef SHIFT_SERIAL
 	 // If Shifter box op, initiate it
 	 else if (x.op_stage2 == OP_Stage2_SH)
-	    shifter_box.req (unpack (funct3 [2]), x.val1, x.val2);
+	    shifter_box.req (
+                 unpack (funct3 [2])
+`ifdef ISA_D
+`ifdef RV32
+               , truncate (x.val1)
+               , truncate (x.val2));
+`else
+               , x.val1
+               , x.val2);
+`endif
+`else
+               , x.val1
+               , x.val2);
+`endif
 `endif
 
 `ifdef ISA_M
 	 // If MBox op, initiate it
 	 else if (x.op_stage2 == OP_Stage2_M) begin
 	    Bool is_OP_not_OP_32 = (x.instr [3] == 1'b0);
-	    mbox.req (is_OP_not_OP_32, funct3, x.val1, x.val2);
+            mbox.req (
+                 is_OP_not_OP_32
+               , funct3
+`ifdef ISA_D
+`ifdef RV64
+               , x.val1
+               , x.val2);
+`else
+               , truncate (x.val1)
+               , truncate (x.val2));
+`endif
+`else
+               , x.val1
+               , x.val2);
+`endif
 	 end
 `endif
 
-`ifdef ISA_FD
+`ifdef ISA_F
 	 // If FBox op, initiate it
-	 else if (x.op_stage2 == OP_Stage2_FD)
-	    fbox.req (funct3, x.val1, x.val2);
+         else if (x.op_stage2 == OP_Stage2_FD) begin
+            // Instr fields required for decode for F/D opcodes
+            let opcode = instr_opcode (x.instr);
+	    let funct7 = instr_funct7 (x.instr);
+            let rs2    = instr_rs2    (x.instr);
+
+	    fbox.req (
+                 opcode
+               , funct7
+               , x.rounding_mode // rm
+               , rs2
+`ifdef ISA_D
+               , x.val1
+               , x.val2
+               , x.val3 
+`else
+`ifdef RV32
+               , extend (x.val1)
+               , extend (x.val2)
+`else
+               , x.val1
+               , x.val2
+`endif
+               , extend (x.val3)
+`endif
+            );
+         end
 `endif
       endaction
    endfunction

--- a/src_Core/Core/CPU_Stage3.bsv
+++ b/src_Core/Core/CPU_Stage3.bsv
@@ -1,4 +1,5 @@
-// Copyright (c) 2016-2018 Bluespec, Inc. All Rights Reserved
+// vim: tw=80:tabstop=8:softtabstop=3:shiftwidth=3:expandtab:
+// Copyright (c) 2016-2019 Bluespec, Inc. All Rights Reserved
 
 package CPU_Stage3;
 
@@ -43,6 +44,9 @@ import Cur_Cycle :: *;
 
 import ISA_Decls   :: *;
 import GPR_RegFile :: *;
+`ifdef ISA_F
+import FPR_RegFile :: *;
+`endif
 import CSR_RegFile :: *;
 import CPU_Globals :: *;
 
@@ -76,6 +80,9 @@ endinterface
 
 module mkCPU_Stage3 #(Bit #(4)         verbosity,
 		      GPR_RegFile_IFC  gpr_regfile,
+`ifdef ISA_F
+		      FPR_RegFile_IFC  fpr_regfile,
+`endif
 		      CSR_RegFile_IFC  csr_regfile)
                     (CPU_Stage3_IFC);
 
@@ -88,6 +95,30 @@ module mkCPU_Stage3 #(Bit #(4)         verbosity,
    // ----------------------------------------------------------------
    // BEHAVIOR
 
+   let bypass_base = Bypass {bypass_state: BYPASS_RD_NONE
+			   , rd:           rg_stage3.rd
+`ifdef ISA_D
+			   , rd_val:       truncate (rg_stage3.rd_val) 
+`else
+			   , rd_val:       rg_stage3.rd_val
+`endif
+                           };
+
+`ifdef ISA_F
+   let fbypass_base = FBypass {bypass_state: BYPASS_RD_NONE
+			   , rd:           rg_stage3.rd
+`ifdef ISA_D
+			   , rd_val:       rg_stage3.rd_val 
+`else
+`ifdef RV64
+			   , rd_val:       extend (rg_stage3.rd_val)
+`else
+			   , rd_val:       rg_stage3.rd_val
+`endif
+`endif
+                           };
+`endif
+
    rule rl_reset;
       f_reset_reqs.deq;
       rg_full <= False;
@@ -98,12 +129,29 @@ module mkCPU_Stage3 #(Bit #(4)         verbosity,
    // Combinational output function
 
    function Output_Stage3 fv_out;
-      return Output_Stage3 {ostatus: (rg_full ? OSTATUS_PIPE : OSTATUS_EMPTY),
-			    bypass:  Bypass {bypass_state: ((rg_full && rg_stage3.rd_valid)
-							    ? BYPASS_RD_RDVAL
-							    : BYPASS_RD_NONE),
-					     rd:           rg_stage3.rd,
-					     rd_val:       rg_stage3.rd_val }};
+      let bypass = bypass_base;
+`ifdef ISA_F
+      let fbypass = fbypass_base;
+      if (rg_stage3.rd_in_fpr) begin
+         bypass.bypass_state = BYPASS_RD_NONE;
+         fbypass.bypass_state = (rg_full && rg_stage3.rd_valid) ? BYPASS_RD_RDVAL
+                                                                : BYPASS_RD_NONE;
+      end
+      else begin
+         fbypass.bypass_state = BYPASS_RD_NONE;
+         bypass.bypass_state = (rg_full && rg_stage3.rd_valid) ? BYPASS_RD_RDVAL
+                                                               : BYPASS_RD_NONE;
+      end
+`else
+      bypass.bypass_state = (rg_full && rg_stage3.rd_valid) ? BYPASS_RD_RDVAL
+                                                            : BYPASS_RD_NONE;
+`endif
+      return Output_Stage3 {ostatus: (rg_full ? OSTATUS_PIPE : OSTATUS_EMPTY)
+                            , bypass : bypass
+`ifdef ISA_F
+                            , fbypass: fbypass
+`endif
+			   };
    endfunction
 
    // ----------------
@@ -113,10 +161,37 @@ module mkCPU_Stage3 #(Bit #(4)         verbosity,
       action
 	 // Writeback Rd if valid
 	 if (rg_stage3.rd_valid) begin
-	    gpr_regfile.write_rd (rg_stage3.rd, rg_stage3.rd_val);
+`ifdef ISA_F
+            if (rg_stage3.rd_in_fpr)
+`ifdef ISA_D
+               fpr_regfile.write_rd (rg_stage3.rd, rg_stage3.rd_val);
+`else
+               fpr_regfile.write_rd (rg_stage3.rd, truncate (rg_stage3.rd_val));
+`endif
+            else
+`ifdef RV64
+               gpr_regfile.write_rd (rg_stage3.rd, rg_stage3.rd_val);
+`endif
+`ifdef RV32
+               gpr_regfile.write_rd (rg_stage3.rd, truncate (rg_stage3.rd_val));
+`endif
+`else
+            gpr_regfile.write_rd (rg_stage3.rd, rg_stage3.rd_val);
+`endif
 	    if (verbosity > 1)
-	       $display ("    S3.fa_deq: write Rd 0x%0h, rd_val 0x%0h",
-			 rg_stage3.rd, rg_stage3.rd_val);
+`ifdef ISA_F
+               if (rg_stage3.rd_in_fpr)
+                  $display ("    S3.fa_deq: write FRd 0x%0h, rd_val 0x%0h",
+                            rg_stage3.rd, rg_stage3.rd_val);
+               else
+`endif
+                  $display ("    S3.fa_deq: write GRd 0x%0h, rd_val 0x%0h",
+                            rg_stage3.rd, rg_stage3.rd_val);
+`ifdef ISA_F
+            // Update FCSR.fflags
+            if (rg_stage3.upd_flags)
+               csr_regfile.update_fcsr_fflags (rg_stage3.fpr_flags);
+`endif
 	 end
       endaction
    endfunction

--- a/src_Core/Core/FPU.bsv
+++ b/src_Core/Core/FPU.bsv
@@ -1,0 +1,149 @@
+// Copyright (c) 2013-2016 Bluespec, Inc. All Rights Reserved
+package FPU;
+
+import FIFOF :: *;
+import RegFile :: *;
+import GetPut :: *;
+import ClientServer :: *;
+
+import FloatingPoint :: *;
+import Divide :: *;
+import SquareRoot ::*;
+import ISA_Decls :: *;
+
+// ================================================================
+// Type definitions
+typedef FloatingPoint#(11,52) FDouble;
+typedef FloatingPoint#(8,23)  FSingle;
+
+typedef union tagged {
+   FDouble D;
+   FSingle S;
+   } FloatU deriving(Bits,Eq);
+
+typedef Tuple5#( FloatU,FloatU,FloatU,RoundMode,FpuOp) Fpu_Req;
+typedef Tuple2#( FloatU, FloatingPoint::Exception )       Fpu_Rsp;
+typedef Server#( Fpu_Req, Fpu_Rsp )             FPU_IFC;
+
+typedef Tuple2#( FDouble, FloatingPoint::Exception )      FpuR;
+
+(* synthesize *)
+module mkFPU ( FPU_IFC );
+`ifdef ISA_FD_FDIV
+   Server#(Tuple2#(UInt#(114),UInt#(57)),Tuple2#(UInt#(57),UInt#(57))) _div <- mkNonPipelinedDivider(2);
+   Server#(UInt#(116),Tuple2#(UInt#(116),Bool)) _sqrt                       <- mkNonPipelinedSquareRooter(2);
+
+   Server#( Tuple3#(FDouble,FDouble,RoundMode),         FpuR ) fpu_div64  <- mkFloatingPointDivider(_div);
+   Server#( Tuple2#(FDouble,RoundMode),                 FpuR ) fpu_sqr64  <- mkFloatingPointSquareRooter(_sqrt);
+`endif
+
+   Server#( Tuple4#(Maybe#(FDouble),FDouble,FDouble,RoundMode), FpuR ) fpu_madd   <- mkFloatingPointFusedMultiplyAccumulate;
+
+   FIFOF#( Fpu_Req )  iFifo        <- mkFIFOF; // TODO: bypass fifos?
+   FIFOF#( Fpu_Rsp )  oFifo        <- mkFIFOF; // TODO: bypass fifos?
+   FIFOF#( RoundMode ) rmdFifo     <- mkFIFOF; // TODO: bypass fifos?
+   FIFOF#( Bool )     isDoubleFifo <- mkFIFOF; // TODO: bypass fifos?
+   FIFOF#( Bool )     isNegateFifo <- mkFIFOF; // TODO: bypass fifos?
+   Reg#(FpuR)         resWire      <- mkWire;
+
+   function FDouble toDouble( FloatU x, RoundMode rmode );
+      if (x matches tagged S .val) begin
+         let r = convert( val , rmode , True );
+         return tpl_1(r);
+      end
+      else if (x matches tagged D .val)
+         return val;
+      else
+         return unpack(0);
+   endfunction
+
+   let x    = iFifo.first();
+   let op1  = tpl_1(x);
+   let op2  = tpl_2(x);
+   let op3  = tpl_3(x);
+   let rmd  = tpl_4(x);
+   let iop  = tpl_5(x);
+
+   FDouble opd1 = toDouble(op1, rmd);
+   FDouble opd2 = toDouble(op2, rmd);
+   FDouble opd3 = toDouble(op3, rmd);
+
+   rule start_op;
+      iFifo.deq();
+      if (op1 matches tagged D .val) isDoubleFifo.enq(True);
+      else                           isDoubleFifo.enq(False);
+
+      if      (iop == FPNMAdd)    isNegateFifo.enq(True);
+      else if (iop == FPNMSub)    isNegateFifo.enq(True);
+      else                        isNegateFifo.enq(False);
+
+      rmdFifo.enq(rmd);
+
+      case ( iop )
+         FPAdd:   fpu_madd.request.put(  tuple4(Valid(opd1), opd2,         one(False), rmd) );
+         FPSub:   fpu_madd.request.put(  tuple4(Valid(opd1), negate(opd2), one(False), rmd) );
+         FPMul:   fpu_madd.request.put(  tuple4(Invalid,     opd1,         opd2,       rmd) );
+`ifdef ISA_FD_FDIV
+         FPDiv:   fpu_div64.request.put( tuple3(opd1, opd2,         rmd) );
+         FPSqrt:  fpu_sqr64.request.put( tuple2(opd1,               rmd) );
+`endif
+         FPMAdd:  fpu_madd.request.put(  tuple4(Valid(opd3),         opd1, opd2, rmd) );
+         FPMSub:  fpu_madd.request.put(  tuple4(Valid(negate(opd3)), opd1, opd2, rmd) );
+         FPNMAdd: fpu_madd.request.put(  tuple4(Valid(opd3),         opd1, opd2, rmd) );
+         FPNMSub: fpu_madd.request.put(  tuple4(Valid(negate(opd3)), opd1, opd2, rmd) );
+      endcase
+
+   endrule
+
+`ifdef ISA_FD_FDIV
+   (* mutually_exclusive = "getResDiv, getResSqr, getResMAdd" *)
+   rule getResDiv;
+      let res <- fpu_div64.response.get();
+      resWire <= res;
+   endrule
+
+   rule getResSqr;
+      let res <- fpu_sqr64.response.get();
+      resWire <= res;
+   endrule
+`endif
+
+   rule getResMAdd;
+      let res <- fpu_madd.response.get();
+      resWire <= res;
+   endrule
+
+   rule passResult;
+      isDoubleFifo.deq();
+      let is64Bits = isDoubleFifo.first();
+
+      isNegateFifo.deq();
+      let negateResult = isNegateFifo.first();
+
+      rmdFifo.deq();
+      let rmode = rmdFifo.first();
+
+      if (is64Bits) begin
+         FDouble   v  = tpl_1(resWire);
+         FloatingPoint::Exception ex = tpl_2(resWire);
+         if (negateResult)
+            v = negate( v );
+         FloatU res = tagged D v;
+         oFifo.enq( tuple2( res, ex ) );
+      end
+      else begin
+         Tuple2#(FSingle,FloatingPoint::Exception) sres = convert( tpl_1(resWire) , rmode , True );
+         FSingle   v  = tpl_1(sres);
+         FloatingPoint::Exception ex = tpl_2(resWire) | tpl_2(sres);
+         if (negateResult)
+            v = negate( v );
+         FloatU res = tagged S v;
+         oFifo.enq( tuple2( res, ex ) );
+      end
+   endrule
+
+   interface request  = toPut( iFifo );
+   interface response = toGet( oFifo );
+
+endmodule
+endpackage

--- a/src_Core/Core/RISCV_FBox.bsv
+++ b/src_Core/Core/RISCV_FBox.bsv
@@ -1,0 +1,909 @@
+// vim: tw=80:tabstop=8:softtabstop=3:shiftwidth=3:expandtab:
+// Copyright (c) 2016-2018 Bluespec, Inc. All Rights Reserved
+
+package RISCV_FBox;
+
+// ================================================================
+// This package executes the 'F, D' extension instructions
+
+// ================================================================
+// Exports
+
+export
+RISCV_FBox_IFC (..),
+mkRISCV_FBox;
+
+// ================================================================
+// BSV Library imports
+
+import FIFOF         :: *;
+import Assert        :: *;
+import ConfigReg     :: *;
+import FShow         :: *;
+import FloatingPoint :: *;
+import GetPut        :: *;
+import ClientServer  :: *;
+import DefaultValue  :: *;
+
+// ----------------
+// BSV additional libs
+
+import Cur_Cycle  :: *;
+import GetPut_Aux :: *;
+
+// ================================================================
+// Project imports
+
+import ISA_Decls :: *;
+import FPU       :: *;
+
+// ================================================================
+// FBox interface
+
+typedef struct {
+   Bit #(64)   value;            // The result rd
+   Bit #(5)    flags;            // FCSR.FFLAGS update value
+} FBoxResult deriving (Bits, Eq, FShow);
+
+typedef enum {
+   FBOX_REQ,                     // FBox is accepting a request
+   FBOX_BUSY,                    // FBox waiting for a response
+   FBOX_RSP                      // FBox driving response
+} FBoxState deriving (Bits, Eq, FShow);
+
+interface RISCV_FBox_IFC;
+   method Action set_verbosity (Bit #(4) verbosity);
+
+   // FBox interface: request
+   (* always_ready *)
+   method Action req (
+        Opcode                      opcode
+      , Bit #(7)                    f7
+      , Bit #(3)                    rm
+      , RegName                     rs2
+      , Bit #(64)                   v1
+      , Bit #(64)                   v2
+      , Bit #(64)                   v3
+   );
+
+   // MBox interface: response
+   (* always_ready *)
+   method Bool valid;
+   (* always_ready *)
+   method Tuple2 #(Bit #(64), Bit #(5)) word;
+endinterface
+
+// ================================================================
+
+(* synthesize *)
+module mkRISCV_FBox (RISCV_FBox_IFC);
+
+   Reg   #(Bit #(4))       cfg_verbosity        <- mkConfigReg (0);
+
+   FIFOF #(Bool)           frmFpuF              <- mkFIFOF;
+
+   Reg   #(FBoxState)      stateR               <- mkReg (FBOX_REQ);
+
+   Reg   #(Maybe #(Tuple7 #(
+        Opcode
+      , Bit #(7)
+      , RegName 
+      , Bit #(3)
+      , Bit #(64)
+      , Bit #(64)
+      , Bit #(64))))       requestR             <- mkReg (tagged Invalid);
+
+   Reg   #(Bool)           dw_valid             <- mkDWire (False);
+   Reg   #(Tuple2 #(
+        Bit #(64)
+      , Bit #(5)))         dw_result            <- mkDWire (?);
+
+   Reg   #(Maybe #(Tuple2 #(
+        Bit #(64)
+      , Bit #(5))))        resultR              <- mkReg (tagged Invalid);
+   
+   FPU_IFC                 fpu                  <- mkFPU;
+
+   // =============================================================
+   // Some helper function
+   // Convert the rounding mode into the format understood by the FPU/PNU
+   function RoundMode fv_getRoundMode (Bit #(3) rm);
+      case (rm)
+         3'h0: return (Rnd_Nearest_Even);
+         3'h1: return (Rnd_Zero);
+         3'h2: return (Rnd_Minus_Inf);
+         3'h3: return (Rnd_Plus_Inf);
+         3'h4: return (Rnd_Nearest_Even); // XXX Different in v2.2 of spec
+         default: return (Rnd_Nearest_Even);
+      endcase
+   endfunction
+
+   // Converts the exception coming from the FPU/PNU to the format for the FCSR
+   function Bit #(5) exception_to_fcsr( FloatingPoint::Exception x );
+      let nv  = x.invalid_op ? 1'b1 : 1'b0 ;
+      let dz  = x.divide_0   ? 1'b1 : 1'b0 ;
+      let of  = x.overflow   ? 1'b1 : 1'b0 ;
+      let uf  = x.underflow  ? 1'b1 : 1'b0 ;
+      let nx  = x.inexact    ? 1'b1 : 1'b0 ;
+      return pack ({nv, dz, of, uf, nx});
+   endfunction
+
+   // Take a single precision value and nanboxes it to be able to write it to a
+   // 64-bit FPR register file. This is necessary if single precision operands
+   // used with a register file capable of holding double precision values
+   function Bit #(64) fv_nanbox (Bit #(64) x);
+      Bit #(64) fill_bits = (64'h1 << 32) - 1;  // [31: 0] all ones
+      Bit #(64) fill_mask = (fill_bits << 32);  // [63:32] all ones
+      return (x | fill_mask);
+   endfunction
+
+   // Drive response to the pipeline
+   function Action fa_driveResponse (Bit #(64) res, Bit #(5) flags);
+      action
+      dw_valid    <= True;
+      dw_result   <= tuple2 (res, flags);
+      endaction
+   endfunction
+
+   // =============================================================
+   // Decode sub-opcodes (a direct lift from the spec)
+   match {.opc, .f7, .rs2, .rm, .v1, .v2, .v3} = requestR.Valid;
+   Bit #(2) f2 = f7[1:0];
+`ifdef ISA_D
+   let isFMADD_D     = (opc == op_FMADD)  && (f2 == 1);
+   let isFMSUB_D     = (opc == op_FMSUB)  && (f2 == 1);
+   let isFNMADD_D    = (opc == op_FNMADD) && (f2 == 1);
+   let isFNMSUB_D    = (opc == op_FNMSUB) && (f2 == 1);
+   let isFADD_D      = (opc == op_FP) && (f7 == f7_FADD_D); 
+   let isFSUB_D      = (opc == op_FP) && (f7 == f7_FSUB_D);
+   let isFMUL_D      = (opc == op_FP) && (f7 == f7_FMUL_D);
+`ifdef ISA_FD_DIV
+   let isFDIV_D      = (opc == op_FP) && (f7 == f7_FDIV_D);
+   let isFSQRT_D     = (opc == op_FP) && (f7 == f7_FSQRT_D);
+`endif
+   let isFSGNJ_D     = (opc == op_FP) && (f7 == f7_FSGNJ_D) && (rm == 0);
+   let isFSGNJN_D    = (opc == op_FP) && (f7 == f7_FSGNJ_D) && (rm == 1);
+   let isFSGNJX_D    = (opc == op_FP) && (f7 == f7_FSGNJ_D) && (rm == 2);
+   let isFCVT_W_D    = (opc == op_FP) && (f7 == f7_FCVT_W_D)  && (rs2 == 0);
+   let isFCVT_WU_D   = (opc == op_FP) && (f7 == f7_FCVT_WU_D) && (rs2 == 1);
+`ifdef RV64
+   let isFCVT_L_D    = (opc == op_FP) && (f7 == f7_FCVT_L_D)  && (rs2 == 2);
+   let isFCVT_LU_D   = (opc == op_FP) && (f7 == f7_FCVT_LU_D) && (rs2 == 3);
+`endif
+   let isFCVT_D_W    = (opc == op_FP) && (f7 == f7_FCVT_D_W)  && (rs2 == 0);
+   let isFCVT_D_WU   = (opc == op_FP) && (f7 == f7_FCVT_D_WU) && (rs2 == 1);
+`ifdef RV64
+   let isFCVT_D_L    = (opc == op_FP) && (f7 == f7_FCVT_D_L)  && (rs2 == 2);
+   let isFCVT_D_LU   = (opc == op_FP) && (f7 == f7_FCVT_D_LU) && (rs2 == 3);
+`endif
+   let isFCVT_D_S    = (opc == op_FP) && (f7 == f7_FCVT_D_S)  && (rs2 == 0);
+   let isFCVT_S_D    = (opc == op_FP) && (f7 == f7_FCVT_S_D)  && (rs2 == 1);
+   let isFMIN_D      = (opc == op_FP) && (f7 == f7_FMIN_D) && (rm == 0);
+   let isFMAX_D      = (opc == op_FP) && (f7 == f7_FMAX_D) && (rm == 1);
+   let isFLE_D       = (opc == op_FP) && (f7 == f7_FCMP_D) && (rm == 0);
+   let isFLT_D       = (opc == op_FP) && (f7 == f7_FCMP_D) && (rm == 1);
+   let isFEQ_D       = (opc == op_FP) && (f7 == f7_FCMP_D) && (rm == 2);
+   let isFMV_X_D     = (opc == op_FP) && (f7 == f7_FMV_X_D);
+   let isFMV_D_X     = (opc == op_FP) && (f7 == f7_FMV_D_X);
+   let isFCLASS_D    = (opc == op_FP) && (f7 == f7_FCLASS_D);
+`endif
+
+   let isFMADD_S     = (opc == op_FMADD)  && (f2 == 0);
+   let isFMSUB_S     = (opc == op_FMSUB)  && (f2 == 0);
+   let isFNMADD_S    = (opc == op_FNMADD) && (f2 == 0);
+   let isFNMSUB_S    = (opc == op_FNMSUB) && (f2 == 0);
+   let isFADD_S      = (opc == op_FP) && (f7 == f7_FADD_S); 
+   let isFSUB_S      = (opc == op_FP) && (f7 == f7_FSUB_S);
+   let isFMUL_S      = (opc == op_FP) && (f7 == f7_FMUL_S);
+`ifdef ISA_FD_DIV
+   let isFDIV_S      = (opc == op_FP) && (f7 == f7_FDIV_S);
+   let isFSQRT_S     = (opc == op_FP) && (f7 == f7_FSQRT_S);
+`endif
+   let isFSGNJ_S     = (opc == op_FP) && (f7 == f7_FSGNJ_S) && (rm == 0);
+   let isFSGNJN_S    = (opc == op_FP) && (f7 == f7_FSGNJ_S) && (rm == 1);
+   let isFSGNJX_S    = (opc == op_FP) && (f7 == f7_FSGNJ_S) && (rm == 2);
+   let isFCVT_W_S    = (opc == op_FP) && (f7 == f7_FCVT_W_S)  && (rs2 == 0);
+   let isFCVT_WU_S   = (opc == op_FP) && (f7 == f7_FCVT_WU_S) && (rs2 == 1);
+`ifdef RV64
+   let isFCVT_L_S    = (opc == op_FP) && (f7 == f7_FCVT_L_S)  && (rs2 == 2);
+   let isFCVT_LU_S   = (opc == op_FP) && (f7 == f7_FCVT_LU_S) && (rs2 == 3);
+`endif
+   let isFCVT_S_W    = (opc == op_FP) && (f7 == f7_FCVT_S_W)  && (rs2 == 0);
+   let isFCVT_S_WU   = (opc == op_FP) && (f7 == f7_FCVT_S_WU) && (rs2 == 1);
+`ifdef RV64
+   let isFCVT_S_L    = (opc == op_FP) && (f7 == f7_FCVT_S_L)  && (rs2 == 2);
+   let isFCVT_S_LU   = (opc == op_FP) && (f7 == f7_FCVT_S_LU) && (rs2 == 3);
+`endif
+   let isFMIN_S      = (opc == op_FP) && (f7 == f7_FMIN_S) && (rm == 0);
+   let isFMAX_S      = (opc == op_FP) && (f7 == f7_FMAX_S) && (rm == 1);
+   let isFLE_S       = (opc == op_FP) && (f7 == f7_FCMP_S) && (rm == 0);
+   let isFLT_S       = (opc == op_FP) && (f7 == f7_FCMP_S) && (rm == 1);
+   let isFEQ_S       = (opc == op_FP) && (f7 == f7_FCMP_S) && (rm == 2);
+   let isFMV_X_W     = (opc == op_FP) && (f7 == f7_FMV_X_W);
+   let isFMV_W_X     = (opc == op_FP) && (f7 == f7_FMV_W_X);
+   let isFCLASS_S    = (opc == op_FP) && (f7 == f7_FCLASS_S);
+
+   // =============================================================
+   // Prepare the operands. The operands come in as raw 64 bits. They need to be
+   // type cast as FSingle of FDouble
+   FSingle sV1, sV2, sV3;
+   FDouble dV1, dV2, dV3;
+
+   sV1 = unpack (v1[31:0]);
+   sV2 = unpack (v2[31:0]);
+   sV3 = unpack (v3[31:0]);
+   dV1 = unpack (v1);
+   dV2 = unpack (v2);
+   dV3 = unpack (v3);
+
+   let rmd = fv_getRoundMode (rm);
+
+   // =============================================================
+   // These rules execute the operations, either dispatch to the FPU/PNU or
+   // locally here in the F-Box
+   Bool validReq = isValid (requestR) && (stateR == FBOX_REQ) ;
+
+   // Single precision operations
+   let cmpres_s = compareFP ( sV1, sV2 );
+   rule doFADD_S ( validReq && isFADD_S );
+      fpu.request.put (tuple5 (tagged S sV1, tagged S sV2, ?, rmd, FPAdd));
+
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFSUB_S ( validReq && isFSUB_S );
+      fpu.request.put (tuple5 (tagged S sV1, tagged S sV2, ?, rmd, FPSub));
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFMUL_S ( validReq && isFMUL_S );
+      fpu.request.put (tuple5 (tagged S sV1, tagged S sV2, ?, rmd, FPMul));
+
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFMADD_S ( validReq && isFMADD_S );
+      fpu.request.put( tuple5( tagged S sV1, tagged S sV2, tagged S sV3, rmd, FPMAdd ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFMSUB_S ( validReq && isFMSUB_S );
+      fpu.request.put( tuple5( tagged S sV1, tagged S sV2, tagged S sV3, rmd, FPMSub ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFNMADD_S ( validReq && isFNMADD_S );
+      fpu.request.put( tuple5( tagged S sV1, tagged S sV2, tagged S sV3, rmd, FPNMAdd ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFNMSUB_S ( validReq && isFNMSUB_S );
+      fpu.request.put( tuple5( tagged S sV1, tagged S sV2, tagged S sV3, rmd, FPNMSub ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+`ifdef ISA_FD_DIV
+   rule doFDIV_S ( validReq && isFDIV_S );
+      fpu.request.put( tuple5( tagged S sV1, tagged S sV2, ?, rmd, FPDiv) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFSQRT_S ( validReq && isFSQRT_S );
+      fpu.request.put( tuple5( tagged S sV1, ?, ?, rmd, FPSqrt) );
+      stateR <= FBOX_BUSY;
+   endrule
+`endif
+
+   rule doFSGNJ_S ( validReq && isFSGNJ_S );
+      let r1 = FSingle {  sign: sV2.sign
+                        , exp:  sV1.exp
+                        , sfd:  sV1.sfd};
+      Bit #(64) res = fv_nanbox (extend (pack (r1)));
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFSGNJN_S ( validReq && isFSGNJN_S );
+      FSingle r1 = FSingle {sign: !sV2.sign,
+                            exp:   sV1.exp,
+                            sfd:   sV1.sfd};
+
+      Bit #(64) res = fv_nanbox (extend (pack (r1)));
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFSGNJX_S ( validReq && isFSGNJX_S );
+      FSingle r1 = FSingle {sign:  (sV1.sign != sV2.sign),
+                            exp:   sV1.exp,
+                            sfd:   sV1.sfd};
+      Bit #(64) res = fv_nanbox (extend (pack (r1)));
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+`ifdef RV64
+   rule doFCVT_S_L ( validReq && isFCVT_S_L );
+      Int#(64) v = unpack ( v1 );
+      match {.f, .e} = Tuple2#(FSingle, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd));
+      Bit #(64) res = fv_nanbox (extend (pack ( f )));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_S_LU ( validReq && isFCVT_S_LU );
+      UInt#(64) v = unpack ( v1 );
+      match {.f, .e} = Tuple2#(FSingle, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd));
+      Bit #(64) res = fv_nanbox (extend (pack ( f )));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+`endif
+
+   rule doFCVT_S_W ( validReq && isFCVT_S_W );
+      Int#(32) v = unpack (truncate ( v1 ));
+      match {.f, .e} = Tuple2#(FSingle, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd));
+      Bit #(64) res = fv_nanbox (extend (pack ( f )));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_S_WU ( validReq && isFCVT_S_WU );
+      UInt#(32) v = unpack (truncate ( v1 ));
+      match {.f, .e} = Tuple2#(FSingle, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd));
+      Bit #(64) res = fv_nanbox (extend (pack ( f )));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+`ifdef RV64
+   rule doFCVT_L_S ( validReq && isFCVT_L_S );
+      FSingle f = sV1;
+      match {.v, .e} = Tuple2#(Int#(64),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd));
+      Bit #(64) res = ( pack (v) );
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_LU_S ( validReq && isFCVT_LU_S );
+      FSingle f = sV1;
+      match {.v, .e} = Tuple2#(UInt#(64),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f,rmd ));
+      Bit #(64) res = ( pack (v) );
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+`endif
+
+   rule doFCVT_W_S ( validReq && isFCVT_W_S );
+      FSingle f = sV1;
+      match {.v, .e} = Tuple2#(Int#(32),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd ));
+      Bit #(64) res = signExtend (pack (v));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_WU_S ( validReq && isFCVT_WU_S );
+      FSingle f = sV1;
+      match {.v, .e} = Tuple2#(UInt#(32),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd ));
+      Bit #(64) res = zeroExtend(pack (v));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMIN_S ( validReq && isFMIN_S );
+      Bit #(64) res = ?;
+      // One or both of the values are NaNs
+      if (cmpres_s == UO) begin
+         if ( isSNaN (sV1) && isSNaN (sV2) )
+            res = fv_nanbox (extend (pack (nanQuiet (sV1))));
+         else if ( isSNaN (sV1) )
+            res = fv_nanbox (extend (pack ( sV2 )));
+         else if ( isSNaN (sV2) )
+            res = fv_nanbox (extend (pack ( sV1 )));
+         else if ( isQNaN (sV1) && isQNaN (sV2) )
+            res = fv_nanbox (extend (pack (nanQuiet (sV1))));
+         else if ( isQNaN (sV1) )
+            res = fv_nanbox (extend (pack ( sV2 )));
+         else if ( isQNaN (sV2) )
+            res = fv_nanbox (extend (pack ( sV1 )));
+      end
+
+      // Both values are numbers
+      else
+         res = (cmpres_s == LT) ? fv_nanbox (extend (pack (sV1)))
+                                : fv_nanbox (extend (pack (sV2)));
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMAX_S ( validReq && isFMAX_S );
+      Bit #(64) res = ?;
+      // One or both of the values are NaNs
+      if (cmpres_s == UO) begin
+         if ( isSNaN (sV1) && isSNaN (sV2) )
+            res = fv_nanbox (extend (pack (nanQuiet (sV1))));
+         else if ( isSNaN (sV1) )
+            res = fv_nanbox (extend (pack ( sV2 )));
+         else if ( isSNaN (sV2) )
+            res = fv_nanbox (extend (pack ( sV1 )));
+         else if ( isQNaN (sV1) && isQNaN (sV2) )
+            res = fv_nanbox (extend (pack (nanQuiet (sV1))));
+         else if ( isQNaN (sV1) )
+            res = fv_nanbox (extend (pack ( sV2 )));
+         else if ( isQNaN (sV2) )
+            res = fv_nanbox (extend (pack ( sV1 )));
+      end
+
+      // Both values are numbers
+      else
+         res = (cmpres_s == LT) ? fv_nanbox (extend (pack (sV2)))
+                                : fv_nanbox (extend (pack (sV1)));
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMV_W_X ( validReq && isFMV_W_X );
+      Bit #(64) res = fv_nanbox (pack ( v1 ));
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMV_X_W ( validReq && isFMV_X_W );
+      Bit #(64) res = signExtend (pack ( sV1 ));
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFEQ_S ( validReq && isFEQ_S );
+      Bit #(64) res = (cmpres_s==EQ ? 1 : 0);
+      FloatingPoint::Exception e = defaultValue;
+      if (isSNaN(sV1) || isSNaN(sV2)) e.invalid_op = True;
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFLT_S ( validReq && isFLT_S );
+      Bit #(64) res = (cmpres_s==LT ? 1 : 0);
+      FloatingPoint::Exception e = defaultValue;
+      if (isNaN(sV1) || isNaN(sV2)) e.invalid_op = True;
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFLE_S ( validReq && isFLE_S );
+      Bit #(64) res = (((cmpres_s==LT) || (cmpres_s==EQ)) ? 1 : 0);
+      FloatingPoint::Exception e = defaultValue;
+      if (isNaN(sV1) || isNaN(sV2)) e.invalid_op = True;
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCLASS_S ( validReq && isFCLASS_S );
+      Bit #(64) res = ?;
+      if (isNaN(sV1)) begin
+	 res = isQNaN(sV1) ? 9 : 8;
+      end
+      else if (isInfinity(sV1)) begin
+	 res = sV1.sign ? 0 : 7;
+      end
+      else if (isZero(sV1)) begin
+	 res = sV1.sign ? 3 : 4;
+      end
+      else if (isSubNormal(sV1)) begin
+	 res = sV1.sign ? 2 : 5;
+      end
+      else begin
+	 res = sV1.sign ? 1 : 6;
+      end
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+
+`ifdef ISA_D
+   // Double precision operations
+   let cmpres_d = compareFP ( dV1, dV2 );
+   rule doFADD_D ( validReq && isFADD_D );
+      fpu.request.put (tuple5 (tagged D dV1, tagged D dV2, ?, rmd, FPAdd));
+
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFSUB_D ( validReq && isFSUB_D );
+      fpu.request.put (tuple5 (tagged D dV1, tagged D dV2, ?, rmd, FPSub));
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFMUL_D ( validReq && isFMUL_D );
+      fpu.request.put (tuple5 (tagged D dV1, tagged D dV2, ?, rmd, FPMul));
+
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFMADD_D ( validReq && isFMADD_D );
+      fpu.request.put( tuple5( tagged D dV1, tagged D dV2, tagged D dV3, rmd, FPMAdd ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFMSUB_D ( validReq && isFMSUB_D );
+      fpu.request.put( tuple5( tagged D dV1, tagged D dV2, tagged D dV3, rmd, FPMSub ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFNMADD_D ( validReq && isFNMADD_D );
+      fpu.request.put( tuple5( tagged D dV1, tagged D dV2, tagged D dV3, rmd, FPNMAdd ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFNMSUB_D ( validReq && isFNMSUB_D );
+      fpu.request.put( tuple5( tagged D dV1, tagged D dV2, tagged D dV3, rmd, FPNMSub ) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+`ifdef ISA_FD_DIV
+   rule doFDIV_D ( validReq && isFDIV_D );
+      fpu.request.put( tuple5( tagged D dV1, tagged D dV2, ?, rmd, FPDiv) );
+      stateR <= FBOX_BUSY;
+   endrule
+
+   rule doFSQRT_D ( validReq && isFSQRT_D );
+      fpu.request.put( tuple5( tagged D dV1, ?, ?, rmd, FPSqrt) );
+      stateR <= FBOX_BUSY;
+   endrule
+`endif
+
+   rule doFSGNJ_D ( validReq && isFSGNJ_D );
+      let r1 = FDouble {  sign: dV2.sign
+                        , exp:  dV1.exp
+                        , sfd:  dV1.sfd};
+      Bit #(64) res = extend (pack (r1));
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFSGNJN_D ( validReq && isFSGNJN_D );
+      let r1 = FDouble {  sign: !dV2.sign
+                        , exp:   dV1.exp
+                        , sfd:   dV1.sfd};
+
+      Bit #(64) res = extend (pack (r1));
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFSGNJX_D ( validReq && isFSGNJX_D );
+      let r1 = FDouble {  sign:  (dV1.sign != dV2.sign)
+                        , exp:   dV1.exp
+                        , sfd:   dV1.sfd};
+      Bit #(64) res = extend (pack (r1));
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_D_W ( validReq && isFCVT_D_W );
+      Int#(32) v = unpack (truncate ( v1 ));
+      match {.f, .e} = Tuple2#(FDouble, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd ));
+      Bit #(64) res = pack ( f );
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_D_WU ( validReq && isFCVT_D_WU );
+      UInt#(32) v = unpack (truncate ( v1 ));
+      match {.f, .e} = Tuple2#(FDouble, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd ));
+      Bit #(64) res = pack ( f );
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_W_D ( validReq && isFCVT_W_D );
+      FDouble f = dV1;
+      match {.v, .e} = Tuple2#(Int#(32),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd ));
+      Bit #(64) res = signExtend(pack (v));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_WU_D ( validReq && isFCVT_WU_D );
+      FDouble f = dV1;
+      match {.v, .e} = Tuple2#(UInt#(32),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd ));
+      Bit #(64) res = zeroExtend(pack(v));
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+`ifdef RV64
+   rule doFCVT_D_L ( validReq && isFCVT_D_L );
+      Int#(64) v = unpack ( v1 );
+      match {.f, .e} = Tuple2#(FDouble, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd ));
+      Bit #(64) res = pack ( f );
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_D_LU ( validReq && isFCVT_D_LU );
+      UInt#(64) v = unpack ( v1 );
+      match {.f, .e} = Tuple2#(FDouble, FloatingPoint::Exception)'(vFixedToFloat( v, 6'd0, rmd ));
+      Bit #(64) res = pack ( f );
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_L_D ( validReq && isFCVT_L_D );
+      FDouble f = dV1;
+      match {.v, .e} = Tuple2#(Int#(64),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd ));
+      Bit #(64) res = pack (v);
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_LU_D ( validReq && isFCVT_LU_D );
+      FDouble f = dV1;
+      match {.v, .e} = Tuple2#(UInt#(64),FloatingPoint::Exception)'(vFloatToFixed( 6'd0, f, rmd ));
+      Bit #(64) res = pack (v);
+      let fcsr    = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+`endif
+
+   rule doFCVT_S_D ( validReq && isFCVT_S_D );
+      Tuple2#(FSingle,FloatingPoint::Exception) f = convert( dV1 , rmd , False );
+      Bit #(64) res = fv_nanbox (extend (pack ( tpl_1(f) )));
+      let fcsr = exception_to_fcsr( tpl_2(f) );
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCVT_D_S ( validReq && isFCVT_D_S );
+      Tuple2#(FDouble,FloatingPoint::Exception) f = convert( sV1 , rmd , False );
+      Bit #(64) res = pack ( tpl_1(f) );
+      let fcsr = exception_to_fcsr( tpl_2(f) );
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMIN_D ( validReq && isFMIN_D );
+      // One or both of the values are NaNs
+      Bit #(64) res = ?;
+      if (cmpres_d == UO) begin
+         if ( isSNaN (dV1) && isSNaN (dV2) )
+            res = pack (nanQuiet (dV1));
+         else if ( isSNaN (dV1) )
+            res = pack ( dV2 );
+         else if ( isSNaN (dV2) )
+            res = pack ( dV1 );
+         else if ( isQNaN (dV1) && isQNaN (dV2) )
+            res = pack (nanQuiet (dV1));
+         else if ( isQNaN (dV1) )
+            res = pack ( dV2 );
+         else if ( isQNaN (dV2) )
+            res = pack ( dV1 );
+      end
+
+      // Both values are numbers
+      else
+         res = (cmpres_d == LT) ? pack (dV1) : pack (dV2);
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMAX_D ( validReq && isFMAX_D );
+      // One or both of the values are NaNs
+      Bit #(64) res = ?;
+      if (cmpres_d == UO) begin
+         if ( isSNaN (dV1) && isSNaN (dV2) )
+            res = pack (nanQuiet (dV1));
+         else if ( isSNaN (dV1) )
+            res = pack ( dV2 );
+         else if ( isSNaN (dV2) )
+            res = pack ( dV1 );
+         else if ( isQNaN (dV1) && isQNaN (dV2) )
+            res = pack (nanQuiet (dV1));
+         else if ( isQNaN (dV1) )
+            res = pack ( dV2 );
+         else if ( isQNaN (dV2) )
+            res = pack ( dV1 );
+      end
+
+      // Both values are numbers
+      else
+         res = (cmpres_s == LT) ? pack (dV2) : pack (dV1);
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFEQ_D ( validReq && isFEQ_D );
+      Bit #(64) res = (cmpres_d==EQ ? 1 : 0);
+      FloatingPoint::Exception e = defaultValue;
+      if (isSNaN(dV1) || isSNaN(dV2)) e.invalid_op = True;
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFLT_D ( validReq && isFLT_D );
+      Bit #(64) res = (cmpres_d==LT ? 1 :0);
+      FloatingPoint::Exception e = defaultValue;
+      if (isNaN(dV1) || isNaN(dV2)) e.invalid_op = True;
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFLE_D ( validReq && isFLE_D );
+      Bit #(64) res = (((cmpres_d==LT) || (cmpres_d==EQ)) ? 1 : 0);
+      FloatingPoint::Exception e = defaultValue;
+      if (isNaN(dV1) || isNaN(dV2)) e.invalid_op = True;
+      let fcsr = exception_to_fcsr(e);
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMV_D_X ( validReq && isFMV_D_X );
+      Bit #(64) res = pack ( v1 );
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFMV_X_D ( validReq && isFMV_X_D );
+      Bit #(64) res = pack ( dV1 );
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   rule doFCLASS_D ( validReq && isFCLASS_D );
+      Bit #(64) res = ?;
+      if (isNaN(dV1)) begin
+	 res = isQNaN(dV1) ? 9 : 8;
+      end
+      else if (isInfinity(dV1)) begin
+	 res = dV1.sign ? 0 : 7;
+      end
+      else if (isZero(dV1)) begin
+	 res = dV1.sign ? 3 : 4;
+      end
+      else if (isSubNormal(dV1)) begin
+	 res = dV1.sign ? 2 : 5;
+      end
+      else begin
+	 res = dV1.sign ? 1 : 6;
+      end
+
+      fa_driveResponse (res, 0);
+      resultR     <= tagged Valid (tuple2 (res, 0));
+      stateR      <= FBOX_RSP;
+   endrule
+`endif
+
+   // =============================================================
+
+   // This rule collects the response from FPU for compute opcodes
+   rule rl_get_fpu_result ((stateR == FBOX_BUSY));
+      Fpu_Rsp r      <- fpu.response.get();
+      match {.v, .e}  = r;
+      Bit #(64) res = ?;
+
+      if (v matches tagged S .out)
+         res = fv_nanbox (extend (pack (out)));
+      else if (v matches tagged D .out)
+         res = extend (pack (out));
+      else
+         res = 0;  // note: just ain't possible
+
+      let fcsr    = exception_to_fcsr( e );
+      fa_driveResponse (res, fcsr);
+      resultR     <= tagged Valid (tuple2 (res, fcsr));
+      stateR      <= FBOX_RSP;
+   endrule
+
+   // This rule drives the results from the FBox to the pipeline
+   rule rl_drive_fpu_result (stateR == FBOX_RSP);
+      dw_valid    <= isValid (resultR);
+      dw_result   <= resultR.Valid;
+   endrule
+
+   // =============================================================
+   // INTERFACE
+   method Action set_verbosity (Bit #(4) verbosity);
+      cfg_verbosity <= verbosity;
+   endmethod
+
+   // FBox interface: request
+   method Action req (
+        Opcode    opcode
+      , Bit #(7)  funct7
+      , Bit #(3)  rounding_mode
+      , Bit #(5)  rs2_name
+      , Bit #(64) val1
+      , Bit #(64) val2
+      , Bit #(64) val3
+   );
+      // Legal instruction
+      requestR <= tagged Valid (
+         tuple7 (opcode, funct7, rs2_name, rounding_mode, val1, val2, val3));
+
+      // Start processing the instruction
+      resultR  <= tagged Invalid;
+      stateR   <= FBOX_REQ;
+   endmethod
+
+   // MBox interface: response
+   method Bool valid;
+      return dw_valid;
+   endmethod
+
+   method Tuple2#(Bit#(64), Bit#(5)) word;
+      return dw_result;
+   endmethod
+
+endmodule
+
+// ================================================================
+
+endpackage

--- a/src_Core/ISA/ISA_Decls.bsv
+++ b/src_Core/ISA/ISA_Decls.bsv
@@ -736,7 +736,10 @@ function Bool fv_is_rd_in_GPR (Bit #(7) funct7, RegName rs2);
                        && (rs2 == 3);
 
 `endif
+   // FCLASS.D also maps to this -- both write to GPR
    let is_FMV_X_D    =    (funct7 == f7_FMV_X_D);
+   // FEQ.D, FLE.D, FLT.D map to this
+   let is_FCMP_D     =    (funct7 == f7_FCMP_S);
 `endif
 
     let is_FCVT_W_S  =    (funct7 == f7_FCVT_W_S)
@@ -750,7 +753,11 @@ function Bool fv_is_rd_in_GPR (Bit #(7) funct7, RegName rs2);
                        && (rs2 == 3);
 `endif
 
+   // FCLASS.S also maps to this -- both write to GPR
    let is_FMV_X_W    =    (funct7 == f7_FMV_X_W);
+
+   // FEQ.S, FLE.S, FLT.S map to this
+   let is_FCMP_S     =    (funct7 == f7_FCMP_S);
 
     return (
           False
@@ -762,6 +769,7 @@ function Bool fv_is_rd_in_GPR (Bit #(7) funct7, RegName rs2);
        || is_FCVT_LU_D
 `endif
        || is_FMV_X_D
+       || is_FCMP_D
 `endif
 `ifdef RV64
        || is_FCVT_L_S
@@ -770,6 +778,7 @@ function Bool fv_is_rd_in_GPR (Bit #(7) funct7, RegName rs2);
        || is_FCVT_W_S
        || is_FCVT_WU_S
        || is_FMV_X_W
+       || is_FCMP_S
     );
 endfunction
 
@@ -841,9 +850,9 @@ function Bool fv_is_fp_instr_legal (
           || ((f7 == f7_FCMP_S)   && ( rm == 0))
           || ((f7 == f7_FCMP_S)   && ( rm == 1))
           || ((f7 == f7_FCMP_S)   && ( rm == 2))
-          ||  (f7 == f7_FMV_X_W) 
-          ||  (f7 == f7_FMV_W_X) 
-          ||  (f7 == f7_FCLASS_S)
+          || ((f7 == f7_FMV_X_W)  && ( rm == 0))
+          || ((f7 == f7_FMV_W_X)  && ( rm == 0))
+          || ((f7 == f7_FCLASS_S) && ( rm == 1))
 `ifdef ISA_D
           ||  (f7 == f7_FADD_D)  
           ||  (f7 == f7_FSUB_D)  
@@ -874,9 +883,9 @@ function Bool fv_is_fp_instr_legal (
           || ((f7 == f7_FCMP_D)   && ( rm == 0))
           || ((f7 == f7_FCMP_D)   && ( rm == 1))
           || ((f7 == f7_FCMP_D)   && ( rm == 2))
-          ||  (f7 == f7_FMV_X_D) 
-          ||  (f7 == f7_FMV_D_X) 
-          ||  (f7 == f7_FCLASS_D)
+          || ((f7 == f7_FMV_X_D)  && ( rm == 0))
+          || ((f7 == f7_FMV_D_X)  && ( rm == 0))
+          || ((f7 == f7_FCLASS_D) && ( rm == 1))
 `endif
          ) return True;
       else return False;

--- a/src_Core/ISA/ISA_Decls.bsv
+++ b/src_Core/ISA/ISA_Decls.bsv
@@ -1,15 +1,18 @@
-// vim: tw=80:tabstop=8:softtabstop=3:shiftwidth=3:expandtab:
 // Copyright (c) 2013-2019 Bluespec, Inc. All Rights Reserved
 
 // ================================================================
 // ISA defs for UC Berkeley RISC V
 //
 // References (from riscv.org):
-//   "The RISC-V Instruction Set Manual
-//    Volume I: User-Level ISA, Version 2.2, May 7, 2017"
+//     The RISC-V Instruction Set Manual
+//     Volume I: Unprivileged ISA
+//     Document Version 20181106-Base-Ratification
+//     November 6, 2018
 //
-//   "The RISC-V Instruction Set Manual
-//    Volume II: Privileged Architecture, Version 1.10, May 7, 2017"
+//     The RISC-V Instruction Set Manual
+//     Volume II: Privileged Architecture
+//     Document Version 20181203-Base-Ratification
+//     December 3, 2018
 //
 // ================================================================
 
@@ -739,7 +742,7 @@ function Bool fv_is_rd_in_GPR (Bit #(7) funct7, RegName rs2);
    // FCLASS.D also maps to this -- both write to GPR
    let is_FMV_X_D    =    (funct7 == f7_FMV_X_D);
    // FEQ.D, FLE.D, FLT.D map to this
-   let is_FCMP_D     =    (funct7 == f7_FCMP_S);
+   let is_FCMP_D     =    (funct7 == f7_FCMP_D);
 `endif
 
     let is_FCVT_W_S  =    (funct7 == f7_FCVT_W_S)

--- a/src_Core/ISA/ISA_Decls.bsv
+++ b/src_Core/ISA/ISA_Decls.bsv
@@ -1,4 +1,5 @@
-// Copyright (c) 2013-2018 Bluespec, Inc. All Rights Reserved
+// vim: tw=80:tabstop=8:softtabstop=3:shiftwidth=3:expandtab:
+// Copyright (c) 2013-2019 Bluespec, Inc. All Rights Reserved
 
 // ================================================================
 // ISA defs for UC Berkeley RISC V
@@ -120,7 +121,7 @@ Bool hasFpu64 = False;
 `endif
 
 typedef  Bit #(FLEN) FP_Value;
-typedef  Bit #(FLEN)  WordFL;    // Raw (unsigned) floating point data
+typedef  Bit #(FLEN)  WordFL;    // Floating point data
 
 typedef  TDiv #(FLEN, Bits_per_Byte)           Bytes_per_WordFL;
 typedef  TLog #(Bytes_per_WordFL)              Bits_per_Byte_in_WordFL;
@@ -130,9 +131,9 @@ typedef  Vector #(Bytes_per_WordFL, Byte)      WordFL_B;
 `endif
 
 `ifdef ISA_F
-`define ISA_F_OR_D
-`elif ISA_D
-`define ISA_F_OR_D
+`ifdef ISA_D
+`define ISA_F_AND_D
+`endif
 `endif
 
 // ================================================================
@@ -209,9 +210,6 @@ typedef struct {
    RegName   rs3;
    CSR_Addr  csr;
 
-`ifdef ISA_F
-   Bit #(2)  funct2;
-`endif
    Bit #(3)  funct3;
    Bit #(5)  funct5;
    Bit #(7)  funct7;
@@ -239,9 +237,6 @@ function Decoded_Instr fv_decode (Instr instr);
 			 rs3:       instr_rs3      (instr),
 			 csr:       instr_csr      (instr),
 
-`ifdef ISA_F
-			 funct2:    instr_funct2   (instr),
-`endif
 			 funct3:    instr_funct3   (instr),
 			 funct5:    instr_funct5   (instr),
 			 funct7:    instr_funct7   (instr),
@@ -264,27 +259,27 @@ endfunction
 // on integrating the FPU as certain instruction now do not require the GPR
 // anymore
 //                IsFP, GPRRd
-function Tuple2# (Bool, Bool) fv_decode_gpr_read (Decoded_Instr di);
-`ifdef ISA_F
-   // FP_LD and FP_ST are treated as non-FP operation as far as GPR reads
-   // are concerned
-   if (di.opcode != op_FP) begin
-      return (tuple2 (False, True));   // Regular op with GPR read
-   end
-
-   // This is an FP operation. The following f5 values would work for F and
-   // D subsets
-   else begin
-      if (   (di.funct5 == f5_FCVT_F_X)
-          || (di.funct5 == f5_FMV_W_X))
-         return (tuple2 (True, True)); // FP op with GPR read
-      else
-         return (tuple2 (True, False));// FP op with no GPR read
-   end
-`else
-   return (tuple2 (False, True));      // Regular op with GPR read
-`endif
-endfunction
+// function Tuple2# (Bool, Bool) fv_decode_gpr_read (Decoded_Instr di);
+// `ifdef ISA_F
+//    // FP_LD and FP_ST are treated as non-FP operation as far as GPR reads
+//    // are concerned
+//    if (di.opcode != op_FP) begin
+//       return (tuple2 (False, True));   // Regular op with GPR read
+//    end
+// 
+//    // This is an FP operation. The following f5 values would work for F and
+//    // D subsets
+//    else begin
+//       if (   (di.funct5 == f5_FCVT_F_X)
+//           || (di.funct5 == f5_FMV_W_X))
+//          return (tuple2 (True, True)); // FP op with GPR read
+//       else
+//          return (tuple2 (True, False));// FP op with no GPR read
+//    end
+// `else
+//    return (tuple2 (False, True));      // Regular op with GPR read
+// `endif
+// endfunction
 
 // ================================================================
 // Instruction constructors
@@ -630,65 +625,288 @@ Opcode op_JAL  = 7'b11_011_11;
 Opcode op_JALR = 7'b11_001_11;
 Bit #(3) funct3_JALR = 3'b000;
 
+`ifdef ISA_F
 // ================================================================
 // Floating Point Instructions
+// Enumeration of floating point opcodes for decode within the FPU
+typedef enum {
+     FPAdd
+   , FPSub
+   , FPMul
+   , FPDiv
+   , FPSqrt
+   , FPMAdd
+   , FPMSub
+   , FPNMAdd
+   , FPNMSub } FpuOp deriving (Bits, Eq, FShow);
+
+// Enumeration of rounding modes
+typedef enum {
+     Rnd_Nearest_Even
+   , Rnd_Zero
+   , Rnd_Minus_Inf
+   , Rnd_Plus_Inf
+   , Rnd_Nearest_Max_Mag
+} RoundMode deriving (Bits, Eq, FShow);
+
 // Funct2 encoding
-Bit #(2) f2_S      = 2'b00;
-Bit #(2) f2_D      = 2'b01;
-Bit #(2) f2_Q      = 2'b11;
+Bit #(2) f2_S           = 2'b00;
+Bit #(2) f2_D           = 2'b01;
+Bit #(2) f2_Q           = 2'b11;
 
 // Floating point Load-Store
-// X is W (32-bit) for ISA_F, D (64-bit) for ISA_D
-Opcode op_FLX      = 7'b00_00_111;
-Opcode op_FSX      = 7'b01_00_111;
+Opcode   op_FSTORE      = 7'b_01_001_11;
+Opcode   op_FLOAD       = 7'b_00_001_11;
+Bit #(3) f3_FSW         = 3'b010;
+Bit #(3) f3_FSD         = 3'b011;
+Bit #(3) f3_FLW         = 3'b010;
+Bit #(3) f3_FLD         = 3'b011;
 
 // Fused FP Multiply Add/Sub instructions
-Opcode op_FMADD    = 7'b10_00_011;
-Opcode op_FMSUB    = 7'b10_00_111;
-Opcode op_FNMSUB   = 7'b10_01_011;
-Opcode op_FNMADD   = 7'b10_01_111;
+Opcode   op_FMADD       = 7'b10_00_011;
+Opcode   op_FMSUB       = 7'b10_00_111;
+Opcode   op_FNMSUB      = 7'b10_01_011;
+Opcode   op_FNMADD      = 7'b10_01_111;
 
 // All other FP intructions
-Opcode op_FP = 7'b10_10_011;
+Opcode   op_FP          = 7'b10_10_011;
 
-Bit #(5) f5_FADD     = 5'b00000;
-Bit #(5) f5_FSUB     = 5'b00001;
-Bit #(5) f5_FMUL     = 5'b00010;
-Bit #(5) f5_FDIV     = 5'b00011;
-Bit #(5) f5_FSQRT    = 5'b01011;
-Bit #(5) f5_FSGNJ    = 5'b00100;
-Bit #(5) f5_FSGNJN   = 5'b00100;
-Bit #(5) f5_FSGNJX   = 5'b00100;
-Bit #(5) f5_FMIN     = 5'b00101;
-Bit #(5) f5_FMAX     = 5'b00101;
-Bit #(5) f5_FEQ      = 5'b10100;
-Bit #(5) f5_FLT      = 5'b10100;
-Bit #(5) f5_FLE      = 5'b10100;
-Bit #(5) f5_FCLASS   = 5'b11100;
+Bit #(7) f7_FADD_D      = 7'h1 ;
+Bit #(7) f7_FSUB_D      = 7'h5 ;
+Bit #(7) f7_FMUL_D      = 7'h9 ;
+Bit #(7) f7_FDIV_D      = 7'hD ;
+Bit #(7) f7_FSQRT_D     = 7'h2D;
+Bit #(7) f7_FCMP_D      = 7'h51;
+Bit #(7) f7_FMIN_D      = 7'h15;
+Bit #(7) f7_FMAX_D      = 7'h15;
+Bit #(7) f7_FSGNJ_D     = 7'h11;
 
-// FP convert instructions
-// To be read as FCVT_DEST_SRC
-// X could be W (32-bit), or L (64-bit) and represents the width of the GPR
-// F could be S or D depending on the funct2 field
-Bit #(5) f5_FCVT_X_F = 5'b11000;
-Bit #(5) f5_FCVT_F_X = 5'b11010;
+Bit #(7) f7_FADD_S      = 7'h0 ;
+Bit #(7) f7_FSUB_S      = 7'h4 ;
+Bit #(7) f7_FMUL_S      = 7'h8 ;
+Bit #(7) f7_FDIV_S      = 7'hC ;
+Bit #(7) f7_FSQRT_S     = 7'h2C;
+Bit #(7) f7_FCMP_S      = 7'h50;
+Bit #(7) f7_FMIN_S      = 7'h14;
+Bit #(7) f7_FMAX_S      = 7'h14;
+Bit #(7) f7_FSGNJ_S     = 7'h10;
 
-// For the FMV instructions there is an inconsistency in naming between F and D
-// subsets. Here the W/D represents the width of the data being moved (32-b) and
-// not its interpretations as SP/DP.
-// Confusingly, for the D subset, the spec uses "D" to indicate 64-bit instead
-// of L.
-Bit #(5) f5_FMV_X_W  = 5'b11100;
-Bit #(5) f5_FMV_W_X  = 5'b11110;
+Bit #(7) f7_FCVT_W_S    = 7'h60;
+Bit #(7) f7_FCVT_WU_S   = 7'h60;
+Bit #(7) f7_FCVT_S_W    = 7'h68;
+Bit #(7) f7_FCVT_S_WU   = 7'h68;
+
+Bit #(7) f7_FCVT_L_S    = 7'h60;
+Bit #(7) f7_FCVT_LU_S   = 7'h60;
+Bit #(7) f7_FCVT_S_L    = 7'h68;
+Bit #(7) f7_FCVT_S_LU   = 7'h68;
+
+Bit #(7) f7_FCVT_S_D    = 7'h20;
+Bit #(7) f7_FCVT_D_S    = 7'h21;
+Bit #(7) f7_FCVT_W_D    = 7'h61;
+Bit #(7) f7_FCVT_WU_D   = 7'h61;
+Bit #(7) f7_FCVT_D_W    = 7'h69;
+Bit #(7) f7_FCVT_D_WU   = 7'h69;
+
+Bit #(7) f7_FCVT_L_D    = 7'h61;
+Bit #(7) f7_FCVT_LU_D   = 7'h61;
+Bit #(7) f7_FCVT_D_L    = 7'h69;
+Bit #(7) f7_FCVT_D_LU   = 7'h69;
+
+Bit #(7) f7_FMV_X_D     = 7'h71;
+Bit #(7) f7_FMV_D_X     = 7'h79;
+Bit #(7) f7_FCLASS_D    = 7'h71;
+Bit #(7) f7_FMV_X_W     = 7'h70;
+Bit #(7) f7_FMV_W_X     = 7'h78;
+Bit #(7) f7_FCLASS_S    = 7'h70;
+
+// fv_is_rd_in_GPR: Checks if the request generates a result which
+// should be written into the GPR
+function Bool fv_is_rd_in_GPR (Bit #(7) funct7, RegName rs2);
 
 `ifdef ISA_D
-Bit #(5) f5_FMV_X_D  = 5'b11100;
-Bit #(5) f5_FMV_D_X  = 5'b11110;
+    let is_FCVT_W_D  =    (funct7 == f7_FCVT_W_D)
+                       && (rs2 == 0);
+    let is_FCVT_WU_D =    (funct7 == f7_FCVT_WU_D)
+                       && (rs2 == 1);
+`ifdef RV64
+    let is_FCVT_L_D  =    (funct7 == f7_FCVT_L_D)
+                       && (rs2 == 2);
+    let is_FCVT_LU_D =    (funct7 == f7_FCVT_LU_D)
+                       && (rs2 == 3);
 
-// Only for ISA_D -- S <-> D conversion. The func2 constains the destination,
-// and rs2 contains the source type
-Bit #(5) f5_FCVT_S_D = 5'b01000;
-Bit #(5) f5_FCVT_D_S = 5'b01000;
+`endif
+   let is_FMV_X_D    =    (funct7 == f7_FMV_X_D);
+`endif
+
+    let is_FCVT_W_S  =    (funct7 == f7_FCVT_W_S)
+                       && (rs2 == 0);
+    let is_FCVT_WU_S =    (funct7 == f7_FCVT_WU_S)
+                       && (rs2 == 1);
+`ifdef RV64
+    let is_FCVT_L_S  =    (funct7 == f7_FCVT_L_S)
+                       && (rs2 == 2);
+    let is_FCVT_LU_S =    (funct7 == f7_FCVT_LU_S)
+                       && (rs2 == 3);
+`endif
+
+   let is_FMV_X_W    =    (funct7 == f7_FMV_X_W);
+
+    return (
+          False
+`ifdef ISA_D
+       || is_FCVT_W_D
+       || is_FCVT_WU_D
+`ifdef RV64
+       || is_FCVT_L_D
+       || is_FCVT_LU_D
+`endif
+       || is_FMV_X_D
+`endif
+`ifdef RV64
+       || is_FCVT_L_S
+       || is_FCVT_LU_S
+`endif
+       || is_FCVT_W_S
+       || is_FCVT_WU_S
+       || is_FMV_X_W
+    );
+endfunction
+
+// Check if a rounding mode value in the FCSR.FRM is valid
+function Bool fv_fcsr_frm_valid (Bit #(3) frm);
+   return (   (frm != 3'b101) 
+           && (frm != 3'b110)
+           && (frm != 3'b111)
+          );
+endfunction 
+
+// Check if a rounding mode value in the instr is valid
+function Bool fv_inst_frm_valid (Bit #(3) frm);
+   return (   (frm != 3'b101) 
+           && (frm != 3'b110)
+          );
+endfunction
+
+// fv_rounding_mode_check
+// Returns the correct rounding mode considering the values in the
+// FCSR and the instruction and checks legality
+function Tuple2# (Bit #(3), Bool) fv_rmode_check (
+   Bit #(3) inst_frm, Bit #(3) fcsr_frm);
+   let rm = (inst_frm == 3'h7) ? fcsr_frm : inst_frm;
+   let rm_is_legal  = (inst_frm == 3'h7) ? fv_fcsr_frm_valid (fcsr_frm)
+                                         : fv_inst_frm_valid (inst_frm);
+   return (tuple2 (rm, rm_is_legal));
+endfunction
+
+// A D instruction requires misa.f to be set as well as misa.d
+function Bool fv_is_fp_instr_legal (
+   Bit #(7) f7, Bit #(3) rm, RegName rs2, Opcode fopc);
+   Bit #(2) f2 = f7[1:0];
+   Bool is_legal = True;
+   if (   (fopc == op_FMADD )
+       || (fopc == op_FMSUB )
+       || (fopc == op_FNMADD)
+       || (fopc == op_FNMSUB))
+`ifdef ISA_D
+      return ((f2 == f2_S) || (f2 == f2_D)); // Both SP and DP are legal
+`else
+      return (f2 == f2_S);                   // Only SP is legal
+`endif
+   else
+      if (    (f7 == f7_FADD_S)  
+          ||  (f7 == f7_FSUB_S)  
+          ||  (f7 == f7_FMUL_S)  
+`ifdef ISA_FD_DIV
+          ||  (f7 == f7_FDIV_S)  
+          ||  (f7 == f7_FSQRT_S) 
+`endif
+          || ((f7 == f7_FSGNJ_S)  && ( rm == 0))
+          || ((f7 == f7_FSGNJ_S)  && ( rm == 1))
+          || ((f7 == f7_FSGNJ_S)  && ( rm == 2))
+          || ((f7 == f7_FCVT_W_S) && (rs2 == 0))
+          || ((f7 == f7_FCVT_WU_S)&& (rs2 == 1))
+`ifdef RV64
+          || ((f7 == f7_FCVT_L_S) && (rs2 == 2))
+          || ((f7 == f7_FCVT_LU_S)&& (rs2 == 3))
+`endif                            
+          || ((f7 == f7_FCVT_S_W) && (rs2 == 0))
+          || ((f7 == f7_FCVT_S_WU)&& (rs2 == 1))             
+`ifdef RV64                       
+          || ((f7 == f7_FCVT_S_L) && (rs2 == 2))
+          || ((f7 == f7_FCVT_S_LU)&& (rs2 == 3))
+`endif
+          || ((f7 == f7_FMIN_S)   && ( rm == 0))
+          || ((f7 == f7_FMAX_S)   && ( rm == 1))
+          || ((f7 == f7_FCMP_S)   && ( rm == 0))
+          || ((f7 == f7_FCMP_S)   && ( rm == 1))
+          || ((f7 == f7_FCMP_S)   && ( rm == 2))
+          ||  (f7 == f7_FMV_X_W) 
+          ||  (f7 == f7_FMV_W_X) 
+          ||  (f7 == f7_FCLASS_S)
+`ifdef ISA_D
+          ||  (f7 == f7_FADD_D)  
+          ||  (f7 == f7_FSUB_D)  
+          ||  (f7 == f7_FMUL_D)  
+`ifdef ISA_FD_DIV
+          ||  (f7 == f7_FDIV_D)  
+          ||  (f7 == f7_FSQRT_D) 
+`endif
+          || ((f7 == f7_FSGNJ_D)  && ( rm == 0))
+          || ((f7 == f7_FSGNJ_D)  && ( rm == 1))
+          || ((f7 == f7_FSGNJ_D)  && ( rm == 2))
+          || ((f7 == f7_FCVT_W_D) && (rs2 == 0))
+          || ((f7 == f7_FCVT_WU_D)&& (rs2 == 1))
+`ifdef RV64
+          || ((f7 == f7_FCVT_L_D) && (rs2 == 2))
+          || ((f7 == f7_FCVT_LU_D)&& (rs2 == 3))
+`endif                            
+          || ((f7 == f7_FCVT_D_W) && (rs2 == 0))
+          || ((f7 == f7_FCVT_D_WU)&& (rs2 == 1))             
+`ifdef RV64                       
+          || ((f7 == f7_FCVT_D_L) && (rs2 == 2))
+          || ((f7 == f7_FCVT_D_LU)&& (rs2 == 3))
+`endif
+          || ((f7 == f7_FCVT_D_S) && (rs2 == 0))
+          || ((f7 == f7_FCVT_S_D) && (rs2 == 1))
+          || ((f7 == f7_FMIN_D)   && ( rm == 0))
+          || ((f7 == f7_FMAX_D)   && ( rm == 1))
+          || ((f7 == f7_FCMP_D)   && ( rm == 0))
+          || ((f7 == f7_FCMP_D)   && ( rm == 1))
+          || ((f7 == f7_FCMP_D)   && ( rm == 2))
+          ||  (f7 == f7_FMV_X_D) 
+          ||  (f7 == f7_FMV_D_X) 
+          ||  (f7 == f7_FCLASS_D)
+`endif
+         ) return True;
+      else return False;
+endfunction
+
+// Returns True if the first operand (val1) should be taken from the GPR
+// instead of the FPR for a FP opcode
+function Bool fv_fp_val1_from_gpr (Opcode opcode, Bit#(7) f7, RegName rs2);
+   return (
+         (opcode == op_FP)
+      && (   False
+`ifdef ISA_D
+          || ((f7 == f7_FCVT_D_W)  && (rs2 == 0))
+          || ((f7 == f7_FCVT_D_WU) && (rs2 == 1))
+`ifdef RV64
+          || ((f7 == f7_FCVT_D_L)  && (rs2 == 2))
+          || ((f7 == f7_FCVT_D_LU) && (rs2 == 3))
+`endif
+          || ((f7 == f7_FMV_D_X))
+`endif
+          || ((f7 == f7_FCVT_S_W)  && (rs2 == 0))
+          || ((f7 == f7_FCVT_S_WU) && (rs2 == 1))
+`ifdef RV64
+          || ((f7 == f7_FCVT_S_L)  && (rs2 == 2))
+          || ((f7 == f7_FCVT_S_LU) && (rs2 == 3))
+`endif
+          || ((f7 == f7_FMV_W_X))
+          )
+   );
+endfunction
 `endif
 
 // ================================================================

--- a/src_Core/ISA/ISA_Decls_C.bsv
+++ b/src_Core/ISA/ISA_Decls_C.bsv
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Bluespec, Inc. All Rights Reserved
+// Copyright (c) 2013-2019 Bluespec, Inc. All Rights Reserved
 
 // ================================================================
 // This is an 'include' file, not a separate BSV package

--- a/src_Core/ISA/ISA_Decls_Priv_M.bsv
+++ b/src_Core/ISA/ISA_Decls_Priv_M.bsv
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Bluespec, Inc. All Rights Reserved
+// Copyright (c) 2013-2019 Bluespec, Inc. All Rights Reserved
 
 // ================================================================
 // This is an 'include' file, not a separate BSV package

--- a/src_Core/ISA/ISA_Decls_Priv_S.bsv
+++ b/src_Core/ISA/ISA_Decls_Priv_S.bsv
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Bluespec, Inc. All Rights Reserved
+// Copyright (c) 2013-2019 Bluespec, Inc. All Rights Reserved
 
 // ================================================================
 // WARNING: this is an 'include' file, not a separate BSV package!

--- a/src_Core/RegFiles/CSR_RegFile_MSU.bsv
+++ b/src_Core/RegFiles/CSR_RegFile_MSU.bsv
@@ -59,6 +59,16 @@ interface CSR_RegFile_IFC;
    (* always_ready *)
    method ActionValue #(WordXL) mav_csr_write (CSR_Addr csr_addr, WordXL word);
 
+`ifdef ISA_F
+   // Read FRM
+   (* always_ready *)
+   method Bit #(3) read_frm;
+
+   // Update FCSR.FFLAGS
+   (* always_ready *)
+   method Action update_fcsr_fflags (Bit #(5) flags);
+`endif
+
    // Read MISA
    (* always_ready *)
    method MISA read_misa;
@@ -202,9 +212,12 @@ function MISA misa_reset_value;
    ms.m = 1'b1;
 `endif
 
-`ifdef ISA_FD
+`ifdef ISA_F
    // Single- and Double-precision Floating Point
    ms.f = 1'b1;
+`endif
+
+`ifdef ISA_D
    ms.d = 1'b1;
 `endif
 
@@ -245,7 +258,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 
    // CSRs
    // User-mode CSRs
-`ifdef ISA_FD
+`ifdef ISA_F
    Reg #(Bit #(5)) rg_fflags <- mkRegU;    // floating point flags
    Reg #(Bit #(3)) rg_frm    <- mkRegU;    // floating point rounding mode
 `endif
@@ -327,7 +340,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 
    rule rl_reset_start (rg_state == RF_RESET_START);
       // User-level CSRs
-`ifdef ISA_FD
+`ifdef ISA_F
       rg_fflags <= 0;
       rg_frm    <= 0;
 `endif
@@ -422,7 +435,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 		     || ((csr_addr_mhpmevent3 <= csr_addr) && (csr_addr <= csr_addr_mhpmevent31))
 
 		     // User mode csrs
-`ifdef ISA_FD
+`ifdef ISA_F
 		     || (csr_addr == csr_addr_fflags)
 		     || (csr_addr == csr_addr_frm)
 		     || (csr_addr == csr_addr_fcsr)
@@ -553,7 +566,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
       else begin
 	 case (csr_addr)
 	    // User mode csrs
-`ifdef ISA_FD
+`ifdef ISA_F
 	    csr_addr_fflags:   m_csr_value = tagged Valid ({ 0, rg_fflags });
 	    csr_addr_frm:      m_csr_value = tagged Valid ({ 0, rg_frm });
 	    csr_addr_fcsr:     m_csr_value = tagged Valid ({ 0, rg_frm, rg_fflags });
@@ -682,7 +695,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	 else
 	    case (csr_addr)
 	       // User mode csrs
-`ifdef ISA_FD
+`ifdef ISA_F
 	       csr_addr_fflags:     begin
 				       result     = zeroExtend (wordxl [4:0]);
 				       rg_fflags <= wordxl [4:0];
@@ -986,6 +999,18 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    method MISA read_misa;
       return misa;
    endmethod
+
+`ifdef ISA_F
+   // Read FCSR.FRM
+   method Bit# (3) read_frm;
+      return rg_frm;
+   endmethod
+
+   // Update FCSR.FFLAGS
+   method Action update_fcsr_fflags (Bit#(5) flags);
+      rg_fflags <= rg_fflags | flags;
+   endmethod
+`endif
 
    // Read MSTATUS
    method WordXL read_mstatus;

--- a/src_Core/RegFiles/CSR_RegFile_UM.bsv
+++ b/src_Core/RegFiles/CSR_RegFile_UM.bsv
@@ -55,6 +55,16 @@ interface CSR_RegFile_IFC;
    (* always_ready *)
    method Action write_csr (CSR_Addr csr_addr, Word word);
 
+`ifdef ISA_F
+   // Read FCSR.FRM
+   (* always_ready *)
+   method Bit #(3) read_frm;
+
+   // Update FCSR.FFLAGS
+   (* always_ready *)
+   method Action update_fcsr_fflags (Bit #(5) flags);
+`endif
+
    // Read MISA
    (* always_ready *)
    method MISA read_misa;
@@ -793,6 +803,18 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    method MISA read_misa;
       return misa;
    endmethod
+
+`ifdef ISA_F
+   // Read FCSR.FRM
+   method Bit# (3) read_frm;
+      return rg_frm;
+   endmethod
+
+   // Update FCSR.FFLAGS
+   method Action update_fcsr_fflags (Bit#(5) flags);
+      rg_fflags <= rg_fflags | flags;
+   endmethod
+`endif
 
    // Read MSTATUS
    method WordXL read_mstatus;

--- a/src_Core/RegFiles/FPR_RegFile.bsv
+++ b/src_Core/RegFiles/FPR_RegFile.bsv
@@ -41,6 +41,8 @@ interface FPR_RegFile_IFC;
    method WordFL read_rs1_port2 (RegName rs1);    // For debugger access only
    (* always_ready *)
    method WordFL read_rs2 (RegName rs2);
+   (* always_ready *)
+   method WordFL read_rs3 (RegName rs3);
 
    // FPR write
    (* always_ready *)
@@ -130,6 +132,10 @@ module mkFPR_RegFile (FPR_RegFile_IFC);
 
    method WordFL read_rs2 (RegName rs2);
       return (regfile.sub (rs2));
+   endmethod
+
+   method WordFL read_rs3 (RegName rs3);
+      return (regfile.sub (rs3));
    endmethod
 
    // FPR write


### PR DESCRIPTION
Added support for FP ops to the pipeline
Introduced the ISA_FD_DIV macro. Hardware floating point divider and sqrt
logic is instantiated when this macro is defined. If not defined, the DIV
SQRT instructions throw ILLEGAL_INSTRUCTION traps