### PR TITLE
AXI4_Deburster.bsv: Make implementation reasonably synthesisable

### DIFF
--- a/src_Testbench/Fabrics/AXI4/AXI4_Deburster.bsv
+++ b/src_Testbench/Fabrics/AXI4/AXI4_Deburster.bsv
@@ -145,18 +145,14 @@ module mkAXI4_Deburster (AXI4_Deburster_IFC #(wd_id, wd_addr, wd_data, wd_user))
       // The actual length of the burst is one more than indicated by axlen
       Bit #(wd_addr) burst_len = zeroExtend (axlen) + 1;
 
-      // find the wrap boundary bit - this becomes the mask - will only work
-      // for burst lengths which are a power of two
-      Bit #(wd_addr) wrap_boundary = (burst_len << pack (axsize));
+      // Compute the mask used to wrap the address, given that burst lenths are
+      // always powers of two
+      Bit #(wd_addr) wrap_mask = (burst_len << pack (axsize)) - 1;
 
-      // For wrapping bursts the wrap_mask needs to be applied to check if the
-      // wrapping boundary has been reached
+      // For wrapping bursts the wrap_mask needs to be applied to wrap the
+      // address round when it reaaches the boundary
       if (axburst == axburst_wrap) begin
-         // The wrapping condition
-         if ((addr % wrap_boundary) == 0) begin
-            // wrap the address - retain all bits except the wrap boundary bit
-            addr = addr - wrap_boundary;
-         end
+         addr = (start_addr & (~ wrap_mask)) | (addr & wrap_mask);
       end
       return addr;
    endfunction


### PR DESCRIPTION
Using the modulus operator does not synthesise efficiently as
wrap_boundary is not statically known to be a power of 2 without
external knowledge of the AXI specification, putting it on a critical
path with over -30ns WNS in the Connectal-based SSITH AWS SoC, and
likely also AWSteria once FPGA builds are attempted.

Instead, exploit the fact that the burst length is required to be a
power of two, and use a bitmask to wrap the address within the aligned
range.