### PR TITLE
Provide an optional AXI4-Lite slave for coherent DMA

### DIFF
--- a/src_Core/BSV_Additional_Libs/CreditCounter.bsv
+++ b/src_Core/BSV_Additional_Libs/CreditCounter.bsv
@@ -37,7 +37,7 @@ module mkCreditCounter (CreditCounter_IFC #(w));
 
    method UInt #(w) value = crg [1];
 
-   method Action incr;
+   method Action incr if (crg [0] != maxBound);
       if (crg [0] == maxBound) begin
 	 $display ("%0d: ERROR: CreditCounter: overflow", cur_cycle);
 	 $finish (1);    // Assertion failure

--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -38,6 +38,10 @@ import Semi_FIFOF :: *;
 
 import AXI4_Types :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 import ISA_Decls :: *;
 
 import TV_Info   :: *;
@@ -1693,6 +1697,13 @@ module mkCPU (CPU_IFC);
 
    // DMem to fabric master interface
    interface  dmem_master = near_mem.dmem_master;
+
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface
+
+`ifdef INCLUDE_DMEM_SLAVE
+   interface  dmem_slave = near_mem.dmem_slave;
+`endif
 
    // ----------------
    // External interrupts

--- a/src_Core/CPU/CPU_IFC.bsv
+++ b/src_Core/CPU/CPU_IFC.bsv
@@ -16,6 +16,10 @@ import ISA_Decls       :: *;
 import AXI4_Types  :: *;
 import Fabric_Defs :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 `ifdef INCLUDE_GDB_CONTROL
 import DM_CPU_Req_Rsp :: *;
 `endif
@@ -39,6 +43,13 @@ interface CPU_IFC;
 
    // DMem to Fabric master interface
    interface AXI4_Master_IFC #(Wd_Id, Wd_Addr, Wd_Data, Wd_User)  dmem_master;
+
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface
+
+`ifdef INCLUDE_DMEM_SLAVE
+   interface AXI4_Lite_Slave_IFC #(Wd_Addr, Wd_Data, Wd_User)  dmem_slave;
+`endif
 
    // ----------------
    // External interrupts

--- a/src_Core/Core/Core.bsv
+++ b/src_Core/Core/Core.bsv
@@ -40,6 +40,10 @@ import AXI4_Fabric  :: *;
 import Fabric_Defs  :: *;    // for Wd_Id, Wd_Addr, Wd_Data, Wd_User
 import SoC_Map      :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 `ifdef INCLUDE_GDB_CONTROL
 import Debug_Module     :: *;
 `endif
@@ -363,6 +367,13 @@ module mkCore (Core_IFC #(N_External_Interrupt_Sources));
 
    // DMem to Fabric master interface
    interface AXI4_Master_IFC  cpu_dmem_master = fabric_2x3.v_to_slaves [default_slave_num];
+
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface
+
+`ifdef INCLUDE_DMEM_SLAVE
+   interface AXI4_Lite_Slave_IFC  cpu_dmem_slave = cpu.dmem_slave;
+`endif
 
    // ----------------------------------------------------------------
    // External interrupt sources

--- a/src_Core/Core/Core_IFC.bsv
+++ b/src_Core/Core/Core_IFC.bsv
@@ -26,6 +26,10 @@ import ClientServer  :: *;
 import AXI4_Types   :: *;
 import Fabric_Defs  :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 // External interrupt request interface
 import PLIC  :: *;
 
@@ -61,6 +65,13 @@ interface Core_IFC #(numeric type t_n_interrupt_sources);
 
    // CPU DMem to Fabric master interface
    interface AXI4_Master_IFC #(Wd_Id, Wd_Addr, Wd_Data, Wd_User) cpu_dmem_master;
+
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface
+
+`ifdef INCLUDE_DMEM_SLAVE
+   interface AXI4_Lite_Slave_IFC #(Wd_Addr, Wd_Data, Wd_User) cpu_dmem_slave;
+`endif
 
    // ----------------------------------------------------------------
    // External interrupt sources

--- a/src_Core/Near_Mem_VM/AXI4_Lite_MMU_Cache_Adapter.bsv
+++ b/src_Core/Near_Mem_VM/AXI4_Lite_MMU_Cache_Adapter.bsv
@@ -1,0 +1,224 @@
+package AXI4_Lite_MMU_Cache_Adapter;
+
+// ================================================================
+// An adapter for an AXI4-Lite master to drive an MMU_Cache_IFC.
+// Supports arbitrarily-strobed writes, but anything that's not naturally
+// sized and aligned will be turned into a series of individual byte
+// reads (with no atomicity guarantees). Being AXI4-Lite, reads are
+// always full width. Thus, this should not be used to access addresses
+// with side-effects.
+
+export AXI4_Lite_MMU_Cache_Adapter_IFC (..),
+       mkAXI4_Lite_MMU_Cache_Adapter;
+
+// ================================================================
+// BSV lib imports
+
+import Assert       :: *;
+import FIFO         :: *;
+import SpecialFIFOs :: *;
+
+// ----------------
+// BSV additional libs
+
+import Semi_FIFOF :: *;
+
+// ================================================================
+// Project imports
+
+import ISA_Decls       :: *;
+import Near_Mem_IFC    :: *;
+import MMU_Cache       :: *;
+import Fabric_Defs     :: *;
+import AXI4_Lite_Types :: *;
+
+// ================================================================
+// Local constants and types
+
+typedef union tagged {
+   void CacheRead;
+   void CacheWrite;
+   void SkippedWrite;
+   Tuple3 #(Fabric_Addr, Fabric_Data, Fabric_Strb) UnnaturalWrite;
+} PendingReq deriving (Bits, Eq, FShow);
+
+// ================================================================
+// Interface
+
+interface AXI4_Lite_MMU_Cache_Adapter_IFC;
+   interface AXI4_Lite_Slave_IFC #(Wd_Addr, Wd_Data, Wd_User) from_master;
+endinterface
+
+// ================================================================
+// Implementation module
+
+module mkAXI4_Lite_MMU_Cache_Adapter #(MMU_Cache_IFC cache)
+				     (AXI4_Lite_MMU_Cache_Adapter_IFC);
+
+   AXI4_Lite_Slave_Xactor_IFC #(Wd_Addr, Wd_Data, Wd_User) xactor_from_master <- mkAXI4_Lite_Slave_Xactor;
+
+   // Stores information associated with the outstanding request. We
+   // want all the properties of a pipeline FIFO, namely that there is
+   // only one outstanding request and that we can simultaneously
+   // consume a response and issue a new request.
+   FIFO #(PendingReq) f_req <- mkPipelineFIFO;
+
+   // For unnatural writes, we track the last byte processed as we
+   // iterate through byte-by-byte, as well as make errors sticky,
+   Reg #(Bit #(ZLSBs_Aligned_Fabric_Addr)) rg_unnatural_last_offset <- mkReg (0);
+   Reg #(AXI4_Lite_Resp) rg_unnatural_bresp <- mkReg (AXI4_LITE_OKAY);
+
+   (* descending_urgency = "rl_rd_xaction, rl_wr_xaction" *)
+   rule rl_wr_xaction;
+      AXI4_Lite_Wr_Addr #(Wd_Addr, Wd_User) wra <- pop_o (xactor_from_master.o_wr_addr);
+      AXI4_Lite_Wr_Data #(Wd_Data)          wrd <- pop_o (xactor_from_master.o_wr_data);
+
+      Bit #(ZLSBs_Aligned_Fabric_Addr) offset = 0;
+      Fabric_Data mask    = 'hFF;
+      Bit #(3)    f3      = f3_SB;
+      Bool        natural = False;
+      case (wrd.wstrb)
+`ifdef FABRIC64
+	 'hFF: begin offset=0; mask = 'hFFFF_FFFF_FFFF_FFFF; f3=f3_SD; natural=True; end
+	 'hF0: begin offset=4; mask =           'hFFFF_FFFF; f3=f3_SW; natural=True; end
+	 'hC0: begin offset=6; mask =                'hFFFF; f3=f3_SH; natural=True; end
+	 'h30: begin offset=4; mask =                'hFFFF; f3=f3_SH; natural=True; end
+	 'h80: begin offset=7; mask =                  'hFF; f3=f3_SB; natural=True; end
+	 'h40: begin offset=6; mask =                  'hFF; f3=f3_SB; natural=True; end
+	 'h20: begin offset=5; mask =                  'hFF; f3=f3_SB; natural=True; end
+	 'h10: begin offset=4; mask =                  'hFF; f3=f3_SB; natural=True; end
+`endif
+	 'hF:  begin offset=0; mask =           'hFFFF_FFFF; f3=f3_SW; natural=True; end
+	 'hC:  begin offset=2; mask =                'hFFFF; f3=f3_SH; natural=True; end
+	 'h3:  begin offset=0; mask =                'hFFFF; f3=f3_SH; natural=True; end
+	 'h8:  begin offset=3; mask =                  'hFF; f3=f3_SB; natural=True; end
+	 'h4:  begin offset=2; mask =                  'hFF; f3=f3_SB; natural=True; end
+	 'h2:  begin offset=1; mask =                  'hFF; f3=f3_SB; natural=True; end
+	 'h1:  begin offset=0; mask =                  'hFF; f3=f3_SB; natural=True; end
+      endcase
+      Bit #(64) addr64 = zeroExtend (wra.awaddr);
+      addr64 [zlsbs_aligned_fabric_addr-1:0] = offset;
+      Bit #(64) st_value = ((zeroExtend (wrd.wdata) >> {offset, 3'b0}) & mask);
+      if (natural || (wrd.wstrb [0] == 1'b1)) begin
+	 cache.req (CACHE_ST,
+		    f3,
+`ifdef ISA_A
+		    ?,
+`endif
+		    truncate (addr64),
+		    st_value,
+		    m_Priv_Mode,
+		    ?,
+		    ?,
+		    ?);
+      end
+      PendingReq req;
+      if (natural)
+	 req = tagged CacheWrite;
+      else if (wrd.wstrb == 0)
+	 req = tagged SkippedWrite;
+      else
+	 req = tagged UnnaturalWrite (tuple3 (wra.awaddr, wrd.wdata, wrd.wstrb));
+      f_req.enq (req);
+   endrule
+
+   rule rl_wr_resp_cache (f_req.first matches tagged CacheWrite &&& cache.valid);
+      let wrr = AXI4_Lite_Wr_Resp {
+	    bresp: cache.exc ? AXI4_LITE_SLVERR : AXI4_LITE_OKAY,
+	    buser: 0
+      };
+      xactor_from_master.i_wr_resp.enq (wrr);
+      f_req.deq;
+   endrule
+
+   rule rl_wr_resp_skipped (f_req.first matches tagged SkippedWrite);
+      let wrr = AXI4_Lite_Wr_Resp {
+	    bresp: AXI4_LITE_OKAY,
+	    buser: 0
+      };
+      xactor_from_master.i_wr_resp.enq (wrr);
+      f_req.deq;
+   endrule
+
+   // rl_wr_xaction will have issued the first byte cache write request
+   // if that lane was strobed. Keep issuing byte requests or skipping
+   // to the next byte until we've processed the whole width.
+   rule rl_wr_unnatural (    f_req.first matches tagged UnnaturalWrite ({ .awaddr, .wdata, .wstrb })
+			 &&& (cache.valid || (wstrb [rg_unnatural_last_offset] == 1'b0)));
+      let bresp = rg_unnatural_bresp;
+      if ((wstrb [rg_unnatural_last_offset] == 1'b1) && cache.valid && cache.exc)
+	 bresp = AXI4_LITE_SLVERR;
+
+      if (rg_unnatural_last_offset == maxBound) begin
+	 let wrr = AXI4_Lite_Wr_Resp {
+	       bresp: bresp,
+	       buser: 0
+	 };
+	 xactor_from_master.i_wr_resp.enq (wrr);
+	 rg_unnatural_last_offset <= 0;
+	 rg_unnatural_bresp <= AXI4_LITE_OKAY;
+	 f_req.deq;
+      end
+      else begin
+	 Bit #(64) addr64 = zeroExtend (awaddr);
+	 Bit #(ZLSBs_Aligned_Fabric_Addr) offset = rg_unnatural_last_offset + 1;
+	 addr64 [zlsbs_aligned_fabric_addr-1:0] = offset;
+	 Bit #(64) st_value = ((zeroExtend (wdata) >> {offset, 3'b0}) & 'hFF);
+	 if (wstrb [offset] == 1'b1) begin
+	    cache.req (CACHE_ST,
+		       f3_SB,
+`ifdef ISA_A
+		       ?,
+`endif
+		       truncate (addr64),
+		       st_value,
+		       m_Priv_Mode,
+		       ?,
+		       ?,
+		       ?);
+	 end
+	 rg_unnatural_last_offset <= offset;
+	 rg_unnatural_bresp <= bresp;
+      end
+   endrule
+
+   rule rl_rd_xaction;
+      AXI4_Lite_Rd_Addr #(Wd_Addr, Wd_User) rda <- pop_o (xactor_from_master.o_rd_addr);
+
+`ifdef FABRIC32
+      Bit #(3) f3 = f3_LW;
+`endif
+`ifdef FABRIC64
+      Bit #(3) f3 = f3_LD;
+`endif
+      Bit #(64) addr64 = zeroExtend (rda.araddr);
+      Bit #(ZLSBs_Aligned_Fabric_Addr) offset = 0;
+      addr64 [zlsbs_aligned_fabric_addr-1:0] = offset;
+      cache.req (CACHE_LD,
+		 f3,
+`ifdef ISA_A
+		 ?,
+`endif
+		 truncate (addr64),
+		 ?,
+		 m_Priv_Mode,
+		 ?,
+		 ?,
+		 ?);
+      f_req.enq (tagged CacheRead);
+   endrule
+
+   rule rl_rd_resp (f_req.first matches tagged CacheRead &&& cache.valid);
+      let rdr = AXI4_Lite_Rd_Data {
+	    rresp: cache.exc ? AXI4_LITE_SLVERR : AXI4_LITE_OKAY,
+	    rdata: truncate (cache.word64),
+	    ruser: 0
+      };
+      xactor_from_master.i_rd_data.enq (rdr);
+      f_req.deq;
+   endrule
+
+   interface from_master = xactor_from_master.axi_side;
+endmodule
+
+endpackage : AXI4_Lite_MMU_Cache_Adapter

--- a/src_Core/Near_Mem_VM/MMU_Cache_Arbiter.bsv
+++ b/src_Core/Near_Mem_VM/MMU_Cache_Arbiter.bsv
@@ -1,0 +1,364 @@
+package MMU_Cache_Arbiter;
+
+// ================================================================
+// An arbiter that splits a single MMU_Cache_IFC into N interface
+// instances. We use a static priority for each master, with low index
+// masters being higher priority. This reduces critical path complexity.
+
+// ================================================================
+// BSV lib imports
+
+import Vector       :: *;
+import GetPut       :: *;
+import ClientServer :: *;
+
+// ================================================================
+// Project imports
+
+import ISA_Decls    :: *;
+import Near_Mem_IFC :: *;
+import MMU_Cache    :: *;
+
+// ================================================================
+// Interface
+
+interface MMU_Cache_Arbiter_IFC #(numeric type num_masters);
+   interface Vector #(num_masters, MMU_Cache_IFC) v_from_masters;
+endinterface
+
+// ================================================================
+// Implementation module
+
+module mkMMU_Cache_Arbiter #(MMU_Cache_IFC cache)
+			   (MMU_Cache_Arbiter_IFC #(num_masters))
+
+   provisos (Add#(a__, 1, num_masters));
+
+   // Whether there is currently a master in control of the cache. If so,
+   // rg_master indicates which master this is.
+   Reg #(Bool) rg_active <- mkReg (False);
+   // One-hot encoding of the current cache master if active, or last master if
+   // inactive (i.e. updated only on acquire, and not release).
+   Reg #(Vector #(num_masters, Bool)) rg_master <- mkReg (unpack (zeroExtend (1'b1)));
+
+   // Pulsed at the start of a cycle to indicate that a response has been
+   // consumed and so the current active master is relinquishing control.
+   PulseWire pw_released_early <- mkPulseWireOR;
+   // Pulsed part way through a cyle to indicate that a master has submitted a
+   // request to the cache and acquired control.
+   PulseWire pw_acquired       <- mkPulseWireOR;
+   // Pulsed part way through a cycle to cancel out pw_acquired for
+   // single-cycle operations.
+   PulseWire pw_released_late  <- mkPulseWireOR;
+
+   // Whether the current cache master has an outstanding reset request.
+   Reg #(Bool) rg_resetting <- mkReg (False);
+   // Pulsed at the start of a cycle when the outstanding reset request has
+   // completed.
+   PulseWire pw_finished_reset <- mkPulseWire;
+   // Pulsed part way through a cycle when a new reset request is issued.
+   PulseWire pw_started_reset  <- mkPulseWire;
+
+   // Whether the current cache master has an outstanding flush request.
+   Reg #(Bool) rg_flushing <- mkReg (False);
+   // Pulsed at the start of a cycle when the outstanding flush request has
+   // completed.
+   PulseWire pw_finished_flush <- mkPulseWire;
+   // Pulsed part way through a cycle when a new flush request is issued.
+   PulseWire pw_started_flush  <- mkPulseWire;
+
+   // Summary bit for rg_resetting and rg_flushing.
+   Reg #(Bool) rg_resetting_or_flushing <- mkReg (False);
+
+   // Enforce priority order for taking control of the cache. Masters consult
+   // every element preceding their PulseWire before they acquire.
+   Vector #(num_masters, PulseWire) v_master_acquired <- replicateM (mkPulseWireOR);
+
+   // Call when a master has consumed a response at the beginning of a cycle
+   // and should release the cache.
+   function Action fa_master_release_early;
+      action
+	 pw_released_early.send;
+      endaction
+   endfunction
+
+   // Call when a master has issued a single-cycle request with no explicit
+   // response signal, ensuring the cache will be released at the end of the
+   // cycle despite also acquiring it.
+   function Action fa_master_release_late;
+      action
+	 pw_released_late.send;
+      endaction
+   endfunction
+
+   // Check whether the given master is awaiting a response.
+   function Bool fn_master_is_active (Integer i);
+      return (rg_active && rg_master [i]);
+   endfunction
+
+   // Check whether the given master is able to acquire the cache, taking into
+   // account the static priority order.
+   function Bool fn_master_can_acquire (Integer i);
+      Bool preempted = False;
+      for (Integer j = 0; j < i; j = j + 1)
+	 preempted = preempted || v_master_acquired [j];
+      return (   (   rg_active
+                  && rg_master [i])
+              || (   (! rg_active)
+	          && (! preempted)));
+   endfunction
+
+   // Call when a master is issuing a request to the cache, ensuring nobody
+   // else uses it until the response is available.
+   function Action fa_master_acquire (Integer i);
+      action
+	 v_master_acquired [i].send;
+	 pw_acquired.send;
+      endaction
+   endfunction
+
+   // A bypassable buffered request for each master. Issued (and invalidated)
+   // in the same cycle if the master can acquire the cache, otherwise buffered
+   // until the first available opportunity.
+   Vector #(num_masters, Array #(Reg #(Bool)))      v_req_valid       <- replicateM (mkCReg (2, False));
+   Vector #(num_masters, Array #(Reg #(CacheOp)))   v_req_op          <- replicateM (mkCRegU (2));
+   Vector #(num_masters, Array #(Reg #(Bit #(3))))  v_req_f3          <- replicateM (mkCRegU (2));
+`ifdef ISA_A
+   Vector #(num_masters, Array #(Reg #(Bit #(7))))  v_req_amo_funct7  <- replicateM (mkCRegU (2));
+`endif
+   Vector #(num_masters, Array #(Reg #(WordXL)))    v_req_addr        <- replicateM (mkCRegU (2));
+   Vector #(num_masters, Array #(Reg #(Bit #(64)))) v_req_st_value    <- replicateM (mkCRegU (2));
+   Vector #(num_masters, Array #(Reg #(Priv_Mode))) v_req_priv        <- replicateM (mkCRegU (2));
+   Vector #(num_masters, Array #(Reg #(Bit #(1))))  v_req_sstatus_SUM <- replicateM (mkCRegU (2));
+   Vector #(num_masters, Array #(Reg #(Bit #(1))))  v_req_mstatus_MXR <- replicateM (mkCRegU (2));
+   Vector #(num_masters, Array #(Reg #(WordXL)))    v_req_satp        <- replicateM (mkCRegU (2));
+
+   // Latched cache output signals for when we've switched to another
+   // master.
+   Vector #(num_masters, Reg #(Bool))      v_rsp_valid      <- replicateM (mkReg (False));
+   Vector #(num_masters, Reg #(WordXL))    v_rsp_addr       <- replicateM (mkRegU);
+   Vector #(num_masters, Reg #(Bit #(64))) v_rsp_word64     <- replicateM (mkRegU);
+   Vector #(num_masters, Reg #(Bit #(64))) v_rsp_st_amo_val <- replicateM (mkRegU);
+   Vector #(num_masters, Reg #(Bool))      v_rsp_exc        <- replicateM (mkReg (False));
+   Vector #(num_masters, Reg #(Exc_Code))  v_rsp_exc_code   <- replicateM (mkRegU);
+
+   Vector #(num_masters, PulseWire) v_latched_rsp    <- replicateM (mkPulseWireOR);
+   Vector #(num_masters, PulseWire) v_invalidate_rsp <- replicateM (mkPulseWireOR);
+   Vector #(num_masters, PulseWire) v_tlb_flush      <- replicateM (mkPulseWire);
+
+   for (Integer i = 0; i < valueOf(num_masters); i = i + 1) begin
+      // The first instance can fire when enabled, but the rules for subsequent
+      // masters are blocked by earlier ones. Unlike the other rules, such an
+      // assertion would only be for performance (or avoiding deadlock), not
+      // for correctness, as we would just risk buffering the request for
+      // longer here and appearing like the cache is stalling, rather than some
+      // other rules in this module which would miss signals on wires.
+      rule rl_send_req (fn_master_can_acquire (i) && v_req_valid [i][1]);
+	 fa_master_acquire (i);
+	 v_req_valid [i][1] <= False;
+	 cache.req (v_req_op          [i][1],
+		    v_req_f3          [i][1],
+		    v_req_amo_funct7  [i][1],
+		    v_req_addr        [i][1],
+		    v_req_st_value    [i][1],
+		    v_req_priv        [i][1],
+		    v_req_sstatus_SUM [i][1],
+		    v_req_mstatus_MXR [i][1],
+		    v_req_satp        [i][1]);
+      endrule
+
+      (* no_implicit_conditions, fire_when_enabled *)
+      rule rl_latch_rsp (fn_master_is_active (i) && cache.valid && (! rg_resetting_or_flushing));
+	 fa_master_release_early;
+	 v_rsp_addr        [i] <= cache.addr;
+	 v_rsp_word64      [i] <= cache.word64;
+	 v_rsp_st_amo_val  [i] <= cache.st_amo_val;
+	 v_rsp_exc         [i] <= cache.exc;
+	 v_rsp_exc_code    [i] <= cache.exc_code;
+	 v_latched_rsp [i].send;
+      endrule
+
+      (* no_implicit_conditions, fire_when_enabled *)
+      rule rl_tlb_flush (v_tlb_flush [i]);
+	 cache.tlb_flush;
+	 // Ensure we update the latched valid signal in case we're
+	 // not the current master or will switch away.
+	 v_invalidate_rsp [i].send;
+      endrule
+
+      (* no_implicit_conditions, fire_when_enabled *)
+      rule rl_update_valid;
+	 if (v_invalidate_rsp [i])
+	    v_rsp_valid [i] <= False;
+	 else if (v_latched_rsp [i])
+	    v_rsp_valid [i] <= True;
+      endrule
+   end
+
+   // Various bookkeeping for shared state
+
+   (* no_implicit_conditions, fire_when_enabled *)
+   rule rl_update_active;
+      if (pw_released_late)
+	 rg_active <= False;
+      else if (pw_acquired)
+	 rg_active <= True;
+      else if (pw_released_early)
+	 rg_active <= False;
+   endrule
+
+   (* no_implicit_conditions, fire_when_enabled *)
+   rule rl_update_master;
+      function Bool pw_read (PulseWire pw) = pw;
+      if (pw_acquired)
+	 rg_master <= map (pw_read, v_master_acquired);
+   endrule
+
+   (* no_implicit_conditions, fire_when_enabled *)
+   rule rl_update_resetting_flushing;
+      let resetting = rg_resetting;
+      let flushing = rg_flushing;
+
+      if (pw_started_reset)
+	 resetting = True;
+      else if (pw_finished_reset)
+	 resetting = False;
+
+      if (pw_started_flush)
+	 flushing = True;
+      else if (pw_finished_flush)
+	 flushing = False;
+
+      rg_resetting <= resetting;
+      rg_flushing <= flushing;
+
+      rg_resetting_or_flushing <= resetting || flushing;
+   endrule
+
+   function MMU_Cache_IFC gen (Integer i);
+      return
+      interface MMU_Cache_IFC;
+	 method Action set_verbosity (Bit #(4) verbosity) if (fn_master_can_acquire (i));
+	    fa_master_acquire (i);
+	    cache.set_verbosity (verbosity);
+	    // set_verbosity is a single-cycle synchronous operation.
+	    fa_master_release_late;
+	 endmethod
+
+	 interface Server server_reset;
+	    interface Put request;
+	       method Action put (Token t) if (fn_master_can_acquire (i) && (! rg_resetting));
+		  fa_master_acquire (i);
+		  cache.server_reset.request.put (t);
+		  pw_started_reset.send;
+	       endmethod
+	    endinterface
+	    interface Get response;
+	       method ActionValue #(Token) get if (fn_master_is_active (i) && rg_resetting);
+		  let t <- cache.server_reset.response.get;
+		  pw_finished_reset.send;
+		  // Update the latched valid signal in case we switch master.
+		  v_invalidate_rsp [i].send;
+		  fa_master_release_early;
+		  return t;
+	       endmethod
+	    endinterface
+	 endinterface
+
+	 method Action req (CacheOp   op,
+			    Bit #(3)  f3,
+`ifdef ISA_A
+			    Bit #(7)  amo_funct7,
+`endif
+			    WordXL    addr,
+			    Bit #(64) st_value,
+			    Priv_Mode priv,
+			    Bit #(1)  sstatus_SUM,
+			    Bit #(1)  mstatus_MXR,
+			    WordXL    satp);
+	    v_req_valid       [i][0] <= True;
+	    v_req_op          [i][0] <= op;
+	    v_req_f3          [i][0] <= f3;
+`ifdef ISA_A
+	    v_req_amo_funct7  [i][0] <= amo_funct7;
+`endif
+	    v_req_addr        [i][0] <= addr;
+	    v_req_st_value    [i][0] <= st_value;
+	    v_req_priv        [i][0] <= priv;
+	    v_req_sstatus_SUM [i][0] <= sstatus_SUM;
+	    v_req_mstatus_MXR [i][0] <= mstatus_MXR;
+	    v_req_satp        [i][0] <= satp;
+	    // Update the latched valid signal in case we don't issue the
+	    // request this cycle.
+	    v_invalidate_rsp [i].send;
+	 endmethod
+
+	 // If this master was in control of the cache in the previous
+	 // cycle then the current output of the cache corresponds to
+	 // this master's actions (regardless of whether we've gone
+	 // idle). Otherwise, use whatever was latched.
+
+	 method Bool valid;
+	    return rg_master [i] ? cache.valid : v_rsp_valid [i];
+	 endmethod
+
+	 method WordXL addr;
+	    return rg_master [i] ? cache.addr : v_rsp_addr [i];
+	 endmethod
+
+	 method Bit #(64) word64;
+	    return rg_master [i] ? cache.word64 : v_rsp_word64 [i];
+	 endmethod
+
+	 method Bit #(64) st_amo_val;
+	    return rg_master [i] ? cache.st_amo_val : v_rsp_st_amo_val [i];
+	 endmethod
+
+	 method Bool exc;
+	    return rg_master [i] ? cache.exc : v_rsp_exc [i];
+	 endmethod
+
+	 method Exc_Code exc_code;
+	    return rg_master [i] ? cache.exc_code : v_rsp_exc_code [i];
+	 endmethod
+
+	 interface Server server_flush;
+	    interface Put request;
+	       method Action put (Token t) if (fn_master_can_acquire (i) && (! rg_flushing));
+		  fa_master_acquire (i);
+		  cache.server_flush.request.put (t);
+		  pw_started_flush.send;
+	       endmethod
+	    endinterface
+	    interface Get response;
+	       method ActionValue #(Token) get if (fn_master_is_active (i) && rg_flushing);
+		  let t <- cache.server_flush.response.get;
+		  pw_finished_flush.send;
+		  // Update the latched valid signal in case we switch master.
+		  v_invalidate_rsp [i].send;
+		  fa_master_release_early;
+		  return t;
+	       endmethod
+	    endinterface
+	 endinterface
+
+	 method Action tlb_flush if (fn_master_can_acquire (i));
+	    fa_master_acquire (i);
+	    v_tlb_flush [i].send;
+	    // Update the latched valid signal in case we switch master.
+	    v_invalidate_rsp [i].send;
+	    // TLB flush is a single-cycle synchronous operation.
+	    fa_master_release_late;
+	 endmethod
+
+	 // NOTE: These are all the same, as the cache's master port is
+	 //       unfortunately part of the interface we need to
+	 //       provide. Consumers should only connect the first!
+	 interface mem_master = cache.mem_master;
+      endinterface;
+   endfunction
+
+   interface v_from_masters = genWith (gen);
+endmodule
+
+endpackage : MMU_Cache_Arbiter

--- a/src_Core/Near_Mem_VM/Near_Mem_Caches.bsv
+++ b/src_Core/Near_Mem_VM/Near_Mem_Caches.bsv
@@ -43,6 +43,11 @@ import MMU_Cache    :: *;
 import AXI4_Types   :: *;
 import Fabric_Defs  :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import MMU_Cache_Arbiter           :: *;
+import AXI4_Lite_MMU_Cache_Adapter :: *;
+`endif
+
 // System address map and pc_reset value
 import SoC_Map :: *;
 
@@ -73,6 +78,12 @@ module mkNear_Mem (Near_Mem_IFC);
 
    MMU_Cache_IFC  icache <- mkMMU_Cache (False);
    MMU_Cache_IFC  dcache <- mkMMU_Cache (True);
+`ifdef INCLUDE_DMEM_SLAVE
+   MMU_Cache_Arbiter_IFC #(2) dcache_arbiter <- mkMMU_Cache_Arbiter (dcache);
+   dcache = dcache_arbiter.v_from_masters [0];
+
+   AXI4_Lite_MMU_Cache_Adapter_IFC dmem_slave_adapter <- mkAXI4_Lite_MMU_Cache_Adapter(dcache_arbiter.v_from_masters [1]);
+`endif
 
    // ----------------------------------------------------------------
    // BEHAVIOR
@@ -192,6 +203,10 @@ module mkNear_Mem (Near_Mem_IFC);
 
    // Fabric side
    interface dmem_master = dcache.mem_master;
+
+`ifdef INCLUDE_DMEM_SLAVE
+   interface dmem_slave = dmem_slave_adapter.from_master;
+`endif
 
    // ----------------
    // FENCE.I: flush both ICache and DCache

--- a/src_Core/Near_Mem_VM/Near_Mem_IFC.bsv
+++ b/src_Core/Near_Mem_VM/Near_Mem_IFC.bsv
@@ -38,6 +38,10 @@ import ISA_Decls :: *;
 import AXI4_Types  :: *;
 import Fabric_Defs :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 // ================================================================
 
 interface Near_Mem_IFC;
@@ -61,6 +65,13 @@ interface Near_Mem_IFC;
 
    // Fabric side
    interface AXI4_Master_IFC #(Wd_Id, Wd_Addr, Wd_Data, Wd_User) dmem_master;
+
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite DMem slave interface
+
+`ifdef INCLUDE_DMEM_SLAVE
+   interface AXI4_Lite_Slave_IFC #(Wd_Addr, Wd_Data, Wd_User) dmem_slave;
+`endif
 
    // ----------------
    // Fences

--- a/src_SSITH_P2/src_BSV/P2_Core.bsv
+++ b/src_SSITH_P2/src_BSV/P2_Core.bsv
@@ -48,6 +48,10 @@ import AXI4_Types   :: *;
 import AXI4_Fabric  :: *;
 import Fabric_Defs  :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 `ifdef INCLUDE_TANDEM_VERIF
 import TV_Info :: *;
 import AXI4_Stream ::*;
@@ -76,6 +80,13 @@ interface P2_Core_IFC;
    // External interrupt sources
    (* always_ready, always_enabled, prefix="" *)
    method  Action interrupt_reqs ((* port="cpu_external_interrupt_req" *) Bit #(N_External_Interrupt_Sources)  reqs);
+
+`ifdef INCLUDE_DMEM_SLAVE
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface
+
+   interface AXI4_Lite_Slave_IFC #(Wd_Addr, Wd_Data, Wd_User) slave0;
+`endif
 
 `ifdef INCLUDE_TANDEM_VERIF
    // ----------------------------------------------------------------
@@ -239,6 +250,13 @@ module mkP2_Core (P2_Core_IFC);
 	 core.core_external_interrupt_sources [j].m_interrupt_req (req_j);
       end
    endmethod
+
+`ifdef INCLUDE_DMEM_SLAVE
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface
+
+   interface AXI4_Lite_Slave_IFC slave0 = core.cpu_dmem_slave;
+`endif
 
 `ifdef INCLUDE_TANDEM_VERIF
    // ----------------------------------------------------------------

--- a/src_Testbench/SoC/SoC_Top.bsv
+++ b/src_Testbench/SoC/SoC_Top.bsv
@@ -36,6 +36,10 @@ import AXI4_Types     :: *;
 import AXI4_Fabric    :: *;
 import AXI4_Deburster :: *;
 
+`ifdef INCLUDE_DMEM_SLAVE
+import AXI4_Lite_Types :: *;
+`endif
+
 import Fabric_Defs :: *;
 import SoC_Map     :: *;
 import SoC_Fabric  :: *;
@@ -192,6 +196,19 @@ module mkSoC_Top (SoC_Top_IFC);
    AXI4_Slave_IFC#(Wd_Id, Wd_Addr, Wd_Data, Wd_User) htif <- mkAxi4LRegFile(bytes_per_htif);
 
    mkConnection (fabric.v_to_slaves [htif_slave_num], htif);
+`endif
+
+   // ----------------------------------------------------------------
+   // Optional AXI4-Lite D-cache slave interface tie-off (not used)
+
+`ifdef INCLUDE_DMEM_SLAVE
+   rule rl_always_dmem_slave (True);
+      core.cpu_dmem_slave.m_arvalid (False, ?, ?, ?);
+      core.cpu_dmem_slave.m_rready (False);
+      core.cpu_dmem_slave.m_awvalid (False, ?, ?, ?);
+      core.cpu_dmem_slave.m_wvalid (False, ?, ?);
+      core.cpu_dmem_slave.m_bready (False);
+   endrule
 `endif
 
    // ----------------


### PR DESCRIPTION
This introduces an AXI4-Lite slave interface at the top level that feeds its requests through the same L1 D-cache as the CPU, which will be used to provide coherent DMA in the Connectal-based AWS F1 SoC variant.

These incoming requests are fulfilled by putting them through a new arbiter that sits between the core and the cache. This arbiter is only present when the AXI4-Lite slave is enabled, but still adds no additional latency to requests except under contention, with all ISA tests taking the same number of cycles in simulation regardless of whether the arbiter is present.

This also adds a small fix to CreditCounter to ensure we never overflow the counter, an issue which long DMA bursts would be more likely to trigger.