### PR TITLE
Optimise some adders in CPU_Fetch_C

### DIFF
--- a/src_Core/CPU/CPU_Fetch_C.bsv
+++ b/src_Core/CPU/CPU_Fetch_C.bsv
@@ -222,7 +222,7 @@ module mkCPU_Fetch_C #(IMem_IFC  imem32) (IMem_IFC);
 	  && (addr_of_b32 == imem32.pc)
 	  && is_32b_instr (imem32.instr [31:16]))
 	 begin
-	    addr_of_b32 = addr_of_b32 + 4;
+	    addr_of_b32 = imem32.pc + 4;
 	 end
 
       imem32.req (f3, addr_of_b32, priv, sstatus_SUM, mstatus_MXR, satp);

--- a/src_Core/CPU/CPU_Fetch_C.bsv
+++ b/src_Core/CPU/CPU_Fetch_C.bsv
@@ -240,23 +240,23 @@ module mkCPU_Fetch_C #(IMem_IFC  imem32) (IMem_IFC);
 	  && is_32b_instr (imem32.instr [31:16]))
 	 begin
 	    addr_of_b32 = imem32.pc + 4;
-            // Here, we know that addr[0:1] == 2'b10 (from is_addr_odd16).
-            // We also know that addr_of_b32 = addr with the bottom 2 bits set to 2'b0
-            // ie addr_of_b32 = addr - 2       (1)
-            // Since after this if statement we make a request to imem32.req with the
-            // address addr_of_b32, the next time imem32.valid is True we will have
-            // imem32.pc = addr_of_b32 + 4     (2)
-            // so we will have imem32.pc = addr + 2     using (1) and (2)
-            // since we set rg_pc = addr above, we then get
-            // imem32.pc = rg_pc + 2
-            rg_imem_pc_is_rg_pc_plus_2 <= True;
+	    // Here, we know that addr[0:1] == 2'b10 (from is_addr_odd16).
+	    // We also know that addr_of_b32 = addr with the bottom 2 bits set to 2'b0
+	    // ie addr_of_b32 = addr - 2       (1)
+	    // Since after this if statement we make a request to imem32.req with the
+	    // address addr_of_b32, the next time imem32.valid is True we will have
+	    // imem32.pc = addr_of_b32 + 4     (2)
+	    // so we will have imem32.pc = addr + 2     using (1) and (2)
+	    // since we set rg_pc = addr above, we then get
+	    // imem32.pc = rg_pc + 2
+	    rg_imem_pc_is_rg_pc_plus_2 <= True;
 	 end
-         else begin
-            // This is similar to the first branch of this if statement, but we get either
-            // imem32.pc = rg_pc  or  imem32.pc = rg_pc - 2
-            // In either case we can assert this to be False
-            rg_imem_pc_is_rg_pc_plus_2 <= False;
-         end
+	 else begin
+	    // This is similar to the first branch of this if statement, but we get either
+	    // imem32.pc = rg_pc  or  imem32.pc = rg_pc - 2
+	    // In either case we can assert this to be False
+	    rg_imem_pc_is_rg_pc_plus_2 <= False;
+	 end
 
       imem32.req (f3, addr_of_b32, priv, sstatus_SUM, mstatus_MXR, satp);
       if (verbosity > 0) begin


### PR DESCRIPTION
This pull request has two commits to reduce the number of adders in CPU_Fetch_C and reduce the area footprint of the design.

There is one change that replaces addr_of_b32 with imem32.pc when they are equal - I would expect either the Bluespec compiler to see this optimisation or the synthesis tool to optimise it away but it looks like neither of these things happen and the design ends up using an extra adder for no reason.

The other change replaces the check for `imem32.pc == rg_pc + 2` with a Bool register that is set each time rg_pc is updated or a request is made to `imem32`.
There are comments in the code that explain my reasoning for this.
I'm not sure if these comments should remain in the final design or not.
Let me know what you think.

Thanks,
Ivan